### PR TITLE
Require symfony/validator 2.5 or higher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "require": {
         "php": ">=5.4.0",
         "commerceguys/intl": "dev-master",
-        "symfony/validator": "2.5.*"
+        "symfony/validator": ">=2.5"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0",


### PR DESCRIPTION
This allows the 2.5 or higher to be installed.
