### PR TITLE
Correct source of locale for formatting address vs country name

### DIFF
--- a/src/Formatter/DefaultFormatter.php
+++ b/src/Formatter/DefaultFormatter.php
@@ -127,7 +127,7 @@ class DefaultFormatter implements FormatterInterface
     public function format(AddressInterface $address)
     {
         $countryCode = $address->getCountryCode();
-        $addressFormat = $this->dataProvider->getAddressFormat($countryCode, $this->locale);
+        $addressFormat = $this->dataProvider->getAddressFormat($countryCode, $address->getLocale());
         $formatString = $addressFormat->getFormat();
 
         $view = $this->buildView($address, $addressFormat);

--- a/tests/Formatter/DefaultFormatterTest.php
+++ b/tests/Formatter/DefaultFormatterTest.php
@@ -195,6 +195,7 @@ class DefaultFormatterTest extends \PHPUnit_Framework_TestCase
         // Traditional Chinese. That's not the case here, for readability.
         $address = new Address();
         $address
+            -> setLocale('zh-hant')
             ->setCountryCode('TW')
             ->setAdministrativeArea('TW-TPE')  // Taipei city
             ->setLocality('TW-TPE-e3cc33')  // Da-an district

--- a/tests/Formatter/PostalLabelFormatterTest.php
+++ b/tests/Formatter/PostalLabelFormatterTest.php
@@ -135,6 +135,44 @@ class PostalLabelFormatterTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @covers \CommerceGuys\Addressing\Formatter\PostalLabelFormatter
+     * @uses   \CommerceGuys\Addressing\Formatter\DefaultFormatter
+     * @uses   \CommerceGuys\Addressing\Model\Address
+     * @uses   \CommerceGuys\Addressing\Model\AddressFormat
+     * @uses   \CommerceGuys\Addressing\Model\FormatStringTrait
+     * @uses   \CommerceGuys\Addressing\Model\Subdivision
+     * @uses   \CommerceGuys\Addressing\Provider\DataProvider
+     * @uses   \CommerceGuys\Addressing\Repository\AddressFormatRepository
+     * @uses   \CommerceGuys\Addressing\Repository\SubdivisionRepository
+     * @uses   \CommerceGuys\Addressing\Repository\DefinitionTranslatorTrait
+     */
+    public function testJapanAddressShippedFromFrance()
+    {
+        $address = new Address();
+        $address
+            ->setLocale('ja')
+            ->setCountryCode('JP')
+            ->setAdministrativeArea('JP-01')
+            ->setLocality('Some City')
+            ->setAddressLine1('Address Line 1')
+            ->setAddressLine2('Address Line 2')
+            ->setPostalCode('04');
+
+        // Test a JP address formatted for sending from France.
+        $expectedLines = [
+            'JAPON - JAPAN',
+            '〒04',
+            '北海道Some City',
+            'Address Line 2',
+            'Address Line 1'
+        ];
+        $this->formatter->setOriginCountryCode('FR');
+        $this->formatter->setLocale('fr');
+        $formattedAddress = $this->formatter->format($address);
+        $this->assertFormattedAddress($expectedLines, $formattedAddress);
+    }
+
+    /**
+     * @covers \CommerceGuys\Addressing\Formatter\PostalLabelFormatter
      * @uses \CommerceGuys\Addressing\Formatter\DefaultFormatter
      * @uses \CommerceGuys\Addressing\Model\Address
      * @uses \CommerceGuys\Addressing\Model\AddressFormat


### PR DESCRIPTION
The Postal label formatter was getting the locale for displaying the address from the locale of the formatter, rather than the locale of the address.

It seems that it should get the locale for the format from the address, so that the address is correctly formatted as originally entered, while the locale of the formatter should match the origin country, and thus determine the language of the country on the label, as shown in the added test.

This commit resolves #29.