### PR TITLE
replace deprecated code in AddressType.php

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,17 @@
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# Custom for Visual Studio
+*.cs     diff=csharp
+
+# Standard to msysgit
+*.doc	 diff=astextplain
+*.DOC	 diff=astextplain
+*.docx diff=astextplain
+*.DOCX diff=astextplain
+*.dot  diff=astextplain
+*.DOT  diff=astextplain
+*.pdf  diff=astextplain
+*.PDF	 diff=astextplain
+*.rtf	 diff=astextplain
+*.RTF	 diff=astextplain

--- a/src/Form/Type/AddressType.php
+++ b/src/Form/Type/AddressType.php
@@ -8,7 +8,7 @@ use CommerceGuys\Addressing\Repository\CountryRepositoryInterface;
 use CommerceGuys\Addressing\Repository\SubdivisionRepositoryInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class AddressType extends AbstractType
 {
@@ -56,7 +56,7 @@ class AddressType extends AbstractType
         $builder->addEventSubscriber(new GenerateAddressFieldsSubscriber($this->addressFormatRepository, $this->subdivisionRepository));
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(['data_class' => 'CommerceGuys\Addressing\Model\Address']);
     }

--- a/src/Form/Type/AddressType.php
+++ b/src/Form/Type/AddressType.php
@@ -8,7 +8,7 @@ use CommerceGuys\Addressing\Repository\CountryRepositoryInterface;
 use CommerceGuys\Addressing\Repository\SubdivisionRepositoryInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\OptionsResolver\OptionsResolver; 
 
 class AddressType extends AbstractType
 {
@@ -56,7 +56,7 @@ class AddressType extends AbstractType
         $builder->addEventSubscriber(new GenerateAddressFieldsSubscriber($this->addressFormatRepository, $this->subdivisionRepository));
     }
 
-    public function configureOptions(OptionsResolver $resolver)
+    public function configureOptions(OptionsResolver $resolver)  
     {
         $resolver->setDefaults(['data_class' => 'CommerceGuys\Addressing\Model\Address']);
     }


### PR DESCRIPTION
As described in https://github.com/symfony/symfony/blob/2.7/UPGRADE-2.7.md#Form 

> In form types and extension overriding the "setDefaultOptions" of the AbstractType or AbstractExtensionType has been deprecated in favor of overriding the new "configureOptions" method.