### PR TITLE
Addresstype change

### DIFF
--- a/src/Form/Type/AddressType.php
+++ b/src/Form/Type/AddressType.php
@@ -8,7 +8,7 @@ use CommerceGuys\Addressing\Repository\CountryRepositoryInterface;
 use CommerceGuys\Addressing\Repository\SubdivisionRepositoryInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
-use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class AddressType extends AbstractType
 {
@@ -56,7 +56,7 @@ class AddressType extends AbstractType
         $builder->addEventSubscriber(new GenerateAddressFieldsSubscriber($this->addressFormatRepository, $this->subdivisionRepository));
     }
 
-    public function setDefaultOptions(OptionsResolverInterface $resolver)
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(['data_class' => 'CommerceGuys\Addressing\Model\Address']);
     }


### PR DESCRIPTION
This pull request should replace request #38. I made a separate branch because I read that there can be only one pull request per branch.

As described in https://github.com/symfony/symfony/blob/2.7/UPGRADE-2.7.md#Form 

> In form types and extension overriding the "setDefaultOptions" of the AbstractType or AbstractExtensionType has been deprecated in favor of overriding the new "configureOptions" method.
