### PR TITLE
Changes locale from 'und' to 'sv'

### DIFF
--- a/resources/address_format/SE.json
+++ b/resources/address_format/SE.json
@@ -1,5 +1,5 @@
 {
-	"locale": "und",
+	"locale": "sv",
 	"format": "%organization\n%recipient\n%addressLine1\n%addressLine2\n%postalCode %locality",
 	"required_fields": [
 		"recipient",


### PR DESCRIPTION
For Sweden locale was set to 'und', this patch fixes that by changing it to the correct 'sv'.