### PR TITLE
Fix AddressFormatValidator violations paths

### DIFF
--- a/src/Validator/Constraints/AddressFormatValidator.php
+++ b/src/Validator/Constraints/AddressFormatValidator.php
@@ -205,7 +205,7 @@ class AddressFormatValidator extends ConstraintValidator
     {
         if ($this->context instanceof \Symfony\Component\Validator\Context\ExecutionContextInterface) {
             $this->context->buildViolation($message)
-                ->atPath('[' . $field . ']')
+                ->atPath($field)
                 ->setInvalidValue($invalidValue)
                 ->addViolation();
         } else {


### PR DESCRIPTION
The errors were shown on the whole form and not on each field.