### PR TITLE
Postal codes starting with 0 return as invalid

### DIFF
--- a/src/Validator/Constraints/AddressFormatValidator.php
+++ b/src/Validator/Constraints/AddressFormatValidator.php
@@ -174,7 +174,7 @@ class AddressFormatValidator extends ConstraintValidator
         if ($fullPattern) {
             // The pattern must match the provided value completely.
             preg_match('/' . $fullPattern . '/i', $postalCode, $matches);
-            if (empty($matches[0]) || $matches[0] != $postalCode) {
+            if (!isset($matches[0]) || $matches[0] != $postalCode) {
                 $this->addViolation(AddressField::POSTAL_CODE, $constraint->invalidMessage, $postalCode, $addressFormat);
 
                 return;
@@ -183,7 +183,7 @@ class AddressFormatValidator extends ConstraintValidator
         if ($startPattern) {
             // The pattern must match the start of the provided value.
             preg_match('/' . $startPattern . '/i', $postalCode, $matches);
-            if (empty($matches[0]) || strpos($postalCode, $matches[0]) !== 0) {
+            if (!isset($matches[0]) || strpos($postalCode, $matches[0]) !== 0) {
                 $this->addViolation(AddressField::POSTAL_CODE, $constraint->invalidMessage, $postalCode, $addressFormat);
 
                 return;


### PR DESCRIPTION
Postal codes in mexico should start with a zero according to the PostalCodePattern

for example the postal code in Distrito Federal - Mexico
```
"MX-DIF": {
			"code": "D.F.",
			"name": "Distrito Federal",
			"postal_code_pattern": "0|1[0-6]"
		}
```

So I suggest to use `isset()` instead of a `empty()` because the empty will fail when the first match is a zero.