### PR TITLE
Fix bug when formatting an address with multibyte (Japanese) characters

### DIFF
--- a/src/Formatter/DefaultFormatter.php
+++ b/src/Formatter/DefaultFormatter.php
@@ -271,8 +271,8 @@ class DefaultFormatter implements FormatterInterface
     {
         $lines = explode("\n", $output);
         foreach ($lines as $index => $line) {
-            $line = trim(mb_ereg_replace('/^[-,]+/', '', $line, 1));
-            $line = mb_ereg_replace('/\s\s+/', ' ', $line);
+			$line = trim(mb_ereg_replace('^[-,]+', '', $line));
+			$line = mb_ereg_replace('\s\s+', ' ', $line);
             $lines[$index] = $line;
         }
         // Remove empty lines.

--- a/src/Formatter/DefaultFormatter.php
+++ b/src/Formatter/DefaultFormatter.php
@@ -271,8 +271,8 @@ class DefaultFormatter implements FormatterInterface
     {
         $lines = explode("\n", $output);
         foreach ($lines as $index => $line) {
-			$line = trim(mb_ereg_replace('^[-,]+', '', $line));
-			$line = mb_ereg_replace('\s\s+', ' ', $line);
+            $line = trim(mb_ereg_replace('^[-,]+', '', $line));
+            $line = mb_ereg_replace('\s\s+', ' ', $line);
             $lines[$index] = $line;
         }
         // Remove empty lines.

--- a/src/Formatter/DefaultFormatter.php
+++ b/src/Formatter/DefaultFormatter.php
@@ -271,8 +271,8 @@ class DefaultFormatter implements FormatterInterface
     {
         $lines = explode("\n", $output);
         foreach ($lines as $index => $line) {
-            $line = trim(preg_replace('/^[-,]+/', '', $line, 1));
-            $line = preg_replace('/\s\s+/', ' ', $line);
+            $line = trim(mb_ereg_replace('/^[-,]+/', '', $line, 1));
+            $line = mb_ereg_replace('/\s\s+/', ' ', $line);
             $lines[$index] = $line;
         }
         // Remove empty lines.

--- a/tests/Formatter/DefaultFormatterTest.php
+++ b/tests/Formatter/DefaultFormatterTest.php
@@ -298,28 +298,28 @@ class DefaultFormatterTest extends \PHPUnit_Framework_TestCase
         $this->assertFormattedAddress($expectedTextLines, $textAddress);
     }
 
-	/**
-	 * @covers \CommerceGuys\Addressing\Formatter\DefaultFormatter
-	 */
-	public function testJapaneseAddress()
-	{
-		$Address = new Address();
-		$Address = $Address
-			->withAddressLine1('ファーストネーム' . ' ' . '姓')
-			->withAddressLine2('家の名前があり')
-			->withLocality('愛住町')
-			->withPostalCode('160-0005')
-			->withAdministrativeArea('JP-13')
-			->withCountryCode('JP');
+    /**
+     * @covers \CommerceGuys\Addressing\Formatter\DefaultFormatter
+     */
+    public function testJapaneseAddress()
+    {
+        $Address = new Address();
+        $Address = $Address
+            ->withAddressLine1('ファーストネーム' . ' ' . '姓')
+            ->withAddressLine2('家の名前があり')
+            ->withLocality('愛住町')
+            ->withPostalCode('160-0005')
+            ->withAdministrativeArea('JP-13')
+            ->withCountryCode('JP');
 
-		$this->formatter->setLocale('en');
+        $this->formatter->setLocale('en');
 
-		$actual = $this->formatter->format($Address);
+        $actual = $this->formatter->format($Address);
 
-		$this->assertContains('ファーストネーム', $actual);
-		$this->assertContains('姓', $actual);
-		$this->assertContains('家の名前があり', $actual);
-	}
+        $this->assertContains('ファーストネーム', $actual);
+        $this->assertContains('姓', $actual);
+        $this->assertContains('家の名前があり', $actual);
+    }
 
     /**
      * Asserts that the formatted address is valid.

--- a/tests/Formatter/DefaultFormatterTest.php
+++ b/tests/Formatter/DefaultFormatterTest.php
@@ -298,6 +298,29 @@ class DefaultFormatterTest extends \PHPUnit_Framework_TestCase
         $this->assertFormattedAddress($expectedTextLines, $textAddress);
     }
 
+	/**
+	 * @covers \CommerceGuys\Addressing\Formatter\DefaultFormatter
+	 */
+	public function testJapaneseAddress()
+	{
+		$Address = new Address();
+		$Address = $Address
+			->withAddressLine1('ファーストネーム' . ' ' . '姓')
+			->withAddressLine2('家の名前があり')
+			->withLocality('愛住町')
+			->withPostalCode('160-0005')
+			->withAdministrativeArea('JP-13')
+			->withCountryCode('JP');
+
+		$this->formatter->setLocale('en');
+
+		$actual = $this->formatter->format($Address);
+
+		$this->assertContains('ファーストネーム', $actual);
+		$this->assertContains('姓', $actual);
+		$this->assertContains('家の名前があり', $actual);
+	}
+
     /**
      * Asserts that the formatted address is valid.
      *


### PR DESCRIPTION
I ran through some issues when dealing with concatenated Japanese chars.