### PR TITLE
Fix example code

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ foreach ($states as $state) {
 }
 
 // Get the subdivisions for Brazilian state Ceará.
-$municipalities = $subdivisionRepository->getAll(['BR', CA']);
+$municipalities = $subdivisionRepository->getAll(['BR', 'CE']);
 foreach ($states as $state) {
     echo $state->getName();
 }


### PR DESCRIPTION
Fixed the sample code (missing open single quote) and also changed the state abbreviations (the correct abbreviations for Ceará is CE instead of CA).