### PR TITLE
Change the local_format in Taiwan

### DIFF
--- a/src/AddressFormat/AddressFormatRepository.php
+++ b/src/AddressFormat/AddressFormatRepository.php
@@ -1362,7 +1362,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
             'TW' => [
                 'locale' => 'zh-Hant',
                 'format' => "%familyName %givenName\n%organization\n%addressLine1\n%addressLine2\n%locality, %administrativeArea %postalCode",
-                'local_format' => "%postalCode\n%administrativeArea%locality\n%addressLine2\n%addressLine1\n%organization\n%familyName %givenName",
+                'local_format' => "%postalCode\n%administrativeArea%locality\n%addressLine1\n%addressLine2\n%organization\n%familyName %givenName",
                 'required_fields' => [
                     'addressLine1', 'locality', 'administrativeArea', 'postalCode',
                 ],


### PR DESCRIPTION
Change the `local_format` in Taiwan 🇹🇼 for the conventional address format.