### PR TITLE
Don't ship unneeded files with composer distribution installs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+/scripts export-ignore
+/tests export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/.travis.yml export-ignore
+/phpcs.xml export-ignore
+/phpunit.xml export-ignore


### PR DESCRIPTION
The files listed in `.gitattributes` are not needed when you have this library installed. Listing them in this file prevents the files from ending up in Composer distributions. This saves traffic and storage. 