### PR TITLE
Include postal code example

### DIFF
--- a/scripts/generate_address_data.php
+++ b/scripts/generate_address_data.php
@@ -280,6 +280,10 @@ function create_address_format_definition($countryCode, $rawDefinition)
     $addressFormat['postal_code_type'] = $rawDefinition['zip_name_type'];
     if (isset($rawDefinition['zip'])) {
         $addressFormat['postal_code_pattern'] = $rawDefinition['zip'];
+        if (isset($rawDefinition['zipex'])) {
+          $postalCodeExamples = explode(',' , $rawDefinition['zipex']);
+          $addressFormat['postal_code_example'] = $postalCodeExamples[0];
+        }
     }
     if (isset($rawDefinition['postprefix'])) {
         // Workaround for https://github.com/googlei18n/libaddressinput/issues/72.
@@ -357,6 +361,10 @@ function create_subdivision_definition($countryCode, $code, $rawDefinition)
         // There are more than 12 000 subdivisions, but only a few Chinese
         // ones specify a full pattern. Therefore, the postal_code_pattern_type
         // value is the same for most subdivisions, and omitted to save space.
+    }
+    if (isset($rawDefinition['zipex'])) {
+      $postalCodeExamples = explode(',' , $rawDefinition['zipex']);
+      $subdivision['postal_code_example'] = $postalCodeExamples[0];
     }
 
     return $subdivision;

--- a/src/AddressFormat/AddressFormat.php
+++ b/src/AddressFormat/AddressFormat.php
@@ -106,6 +106,13 @@ class AddressFormat
     protected $postalCodePrefix;
 
     /**
+     * An example postal code which follows the postal code pattern.
+     *
+     * @var string
+     */
+    protected $postalCodeExample;
+
+    /**
      * The subdivision depth.
      *
      * @var int
@@ -370,6 +377,21 @@ class AddressFormat
     public function getPostalCodePrefix()
     {
         return $this->postalCodePrefix;
+    }
+
+    /**
+     * Gets the postal code example.
+     *
+     * This is an example postal code used to provide additional context to the
+     * end-user. It can be displayed as a placeholder, field description or as
+     * part of the validation.
+     * (E.g. Zip code 12345 is not valid for Louisana (Example: 70001).
+     *
+     * @return string|null A valid postal code example.
+     */
+    public function getPostalCodeExample()
+    {
+        return $this->postalCodeExample;
     }
 
     /**

--- a/src/AddressFormat/AddressFormatRepository.php
+++ b/src/AddressFormat/AddressFormatRepository.php
@@ -97,10 +97,12 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
             'AC' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%postalCode",
                 'postal_code_pattern' => 'ASCN 1ZZ',
+                'postal_code_example' => 'ASCN 1ZZ',
             ],
             'AD' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => 'AD[1-7]0\d',
+                'postal_code_example' => 'AD100',
                 'subdivision_depth' => 1,
             ],
             'AE' => [
@@ -114,6 +116,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
             'AF' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%postalCode",
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '1001',
             ],
             'AG' => [
                 'required_fields' => [
@@ -123,14 +126,17 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
             'AI' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%postalCode",
                 'postal_code_pattern' => '(?:AI-)?2640',
+                'postal_code_example' => '2640',
             ],
             'AL' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode\n%locality",
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '1001',
             ],
             'AM' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode\n%locality\n%administrativeArea",
                 'postal_code_pattern' => '(?:37)?\d{4}',
+                'postal_code_example' => '375010',
                 'subdivision_depth' => 1,
             ],
             'AR' => [
@@ -139,6 +145,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'addressLine2', 'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '((?:[A-HJ-NP-Z])?\d{4})([A-Z]{3})?',
+                'postal_code_example' => 'C1070AAM',
                 'subdivision_depth' => 1,
             ],
             'AS' => [
@@ -152,6 +159,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 'administrative_area_type' => 'state',
                 'postal_code_type' => 'zip',
                 'postal_code_pattern' => '(96799)(?:[ \-](\d{4}))?',
+                'postal_code_example' => '96799',
             ],
             'AT' => [
                 'format' => "%organization\n%givenName %familyName\n%addressLine1\n%addressLine2\n%postalCode %locality",
@@ -159,6 +167,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '1010',
             ],
             'AU' => [
                 'format' => "%organization\n%givenName %familyName\n%addressLine1\n%addressLine2\n%locality %administrativeArea %postalCode",
@@ -171,6 +180,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 'administrative_area_type' => 'state',
                 'locality_type' => 'suburb',
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '2060',
                 'subdivision_depth' => 1,
             ],
             'AX' => [
@@ -179,25 +189,30 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '22\d{3}',
+                'postal_code_example' => '22150',
                 'postal_code_prefix' => 'AX-',
             ],
             'AZ' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '1000',
                 'postal_code_prefix' => 'AZ ',
             ],
             'BA' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '71000',
             ],
             'BB' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality, %administrativeArea %postalCode",
                 'administrative_area_type' => 'parish',
                 'postal_code_pattern' => 'BB\d{5}',
+                'postal_code_example' => 'BB23026',
             ],
             'BD' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality - %postalCode",
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '1340',
             ],
             'BE' => [
                 'format' => "%organization\n%givenName %familyName\n%addressLine1\n%addressLine2\n%postalCode %locality",
@@ -205,6 +220,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '4000',
             ],
             'BF' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %sortingCode",
@@ -212,10 +228,12 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
             'BG' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '1000',
             ],
             'BH' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %postalCode",
                 'postal_code_pattern' => '(?:\d|1[0-2])\d{2}',
+                'postal_code_example' => '317',
             ],
             'BJ' => [
                 'uppercase_fields' => [
@@ -231,14 +249,17 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'addressLine2', 'locality', 'sortingCode',
                 ],
                 'postal_code_pattern' => '9[78][01]\d{2}',
+                'postal_code_example' => '97100',
             ],
             'BM' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %postalCode",
                 'postal_code_pattern' => '[A-Z]{2} ?[A-Z0-9]{2}',
+                'postal_code_example' => 'FL 07',
             ],
             'BN' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %postalCode",
                 'postal_code_pattern' => '[A-Z]{2} ?\d{4}',
+                'postal_code_example' => 'BT2328',
             ],
             'BO' => [
                 'uppercase_fields' => [
@@ -256,6 +277,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 'administrative_area_type' => 'state',
                 'dependent_locality_type' => 'neighborhood',
                 'postal_code_pattern' => '\d{5}-?\d{3}',
+                'postal_code_example' => '40301-110',
                 'subdivision_depth' => 2,
             ],
             'BS' => [
@@ -266,10 +288,12 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
             'BT' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %postalCode",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '11001',
             ],
             'BY' => [
                 'format' => "%administrativeArea\n%postalCode %locality\n%addressLine1\n%addressLine2\n%organization\n%givenName %familyName",
                 'postal_code_pattern' => '\d{6}',
+                'postal_code_example' => '223016',
             ],
             'CA' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %administrativeArea %postalCode",
@@ -280,6 +304,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'addressLine2', 'locality', 'familyName', 'additionalName', 'givenName', 'organization', 'administrativeArea', 'postalCode',
                 ],
                 'postal_code_pattern' => '[ABCEGHJKLMNPRSTVXY]\d[ABCEGHJ-NPRSTV-Z] ?\d[ABCEGHJ-NPRSTV-Z]\d',
+                'postal_code_example' => 'H3Z 2Y7',
                 'subdivision_depth' => 1,
             ],
             'CC' => [
@@ -288,14 +313,17 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'administrativeArea',
                 ],
                 'postal_code_pattern' => '6799',
+                'postal_code_example' => '6799',
             ],
             'CH' => [
                 'format' => "%organization\n%givenName %familyName\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'required_fields' => [
                     'addressLine1', 'locality', 'postalCode',
                 ],
-                'uppercase_fields' => [],
+                'uppercase_fields' => [
+                ],
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '2544',
                 'postal_code_prefix' => 'CH-',
             ],
             'CI' => [
@@ -304,6 +332,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
             'CL' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality\n%administrativeArea",
                 'postal_code_pattern' => '\d{7}',
+                'postal_code_example' => '8340457',
                 'subdivision_depth' => 2,
             ],
             'CN' => [
@@ -318,6 +347,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 ],
                 'dependent_locality_type' => 'district',
                 'postal_code_pattern' => '\d{6}',
+                'postal_code_example' => '266033',
                 'subdivision_depth' => 3,
             ],
             'CO' => [
@@ -327,6 +357,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 ],
                 'administrative_area_type' => 'department',
                 'postal_code_pattern' => '\d{6}',
+                'postal_code_example' => '111221',
                 'subdivision_depth' => 1,
             ],
             'CR' => [
@@ -335,16 +366,19 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'administrativeArea',
                 ],
                 'postal_code_pattern' => '\d{4,5}|\d{3}-\d{4}',
+                'postal_code_example' => '1000',
             ],
             'CU' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %administrativeArea\n%postalCode",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '10700',
                 'subdivision_depth' => 1,
             ],
             'CV' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality\n%administrativeArea",
                 'administrative_area_type' => 'island',
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '7600',
                 'subdivision_depth' => 1,
             ],
             'CX' => [
@@ -353,10 +387,12 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'administrativeArea',
                 ],
                 'postal_code_pattern' => '6798',
+                'postal_code_example' => '6798',
             ],
             'CY' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '2008',
             ],
             'CZ' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
@@ -364,6 +400,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '\d{3} ?\d{2}',
+                'postal_code_example' => '100 00',
             ],
             'DE' => [
                 'format' => "%organization\n%givenName %familyName\n%addressLine1\n%addressLine2\n%postalCode %locality",
@@ -371,6 +408,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '26133',
             ],
             'DK' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
@@ -378,14 +416,17 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '8660',
             ],
             'DO' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '11903',
             ],
             'DZ' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '40304',
             ],
             'EC' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode\n%locality",
@@ -393,6 +434,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '\d{6}',
+                'postal_code_example' => '090105',
             ],
             'EE' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality %administrativeArea",
@@ -401,15 +443,18 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 ],
                 'administrative_area_type' => 'county',
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '69501',
             ],
             'EG' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%administrativeArea\n%postalCode",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '12411',
                 'subdivision_depth' => 1,
             ],
             'EH' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '70000',
             ],
             'ES' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality %administrativeArea",
@@ -420,11 +465,13 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'administrativeArea',
                 ],
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '28039',
                 'subdivision_depth' => 1,
             ],
             'ET' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '1000',
             ],
             'FI' => [
                 'format' => "%organization\n%givenName %familyName\n%addressLine1\n%addressLine2\n%postalCode %locality",
@@ -432,6 +479,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '00550',
                 'postal_code_prefix' => 'FI-',
             ],
             'FK' => [
@@ -443,6 +491,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => 'FIQQ 1ZZ',
+                'postal_code_example' => 'FIQQ 1ZZ',
             ],
             'FM' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %administrativeArea %postalCode",
@@ -455,14 +504,16 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 'administrative_area_type' => 'state',
                 'postal_code_type' => 'zip',
                 'postal_code_pattern' => '(9694[1-4])(?:[ \-](\d{4}))?',
+                'postal_code_example' => '96941',
             ],
             'FO' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{3}',
+                'postal_code_example' => '100',
                 'postal_code_prefix' => 'FO',
             ],
             'FR' => [
-                'format' => "%organization\n%givenName %familyName\n%addressLine1\n%addressLine2\n%postalCode %locality %sortingCode",
+                'format' => "%organization\n%givenName %familyName\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'required_fields' => [
                     'addressLine1', 'locality', 'postalCode',
                 ],
@@ -470,6 +521,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'sortingCode',
                 ],
                 'postal_code_pattern' => '\d{2} ?\d{3}',
+                'postal_code_example' => '33380',
             ],
             'GB' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%postalCode",
@@ -481,10 +533,12 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 ],
                 'locality_type' => 'post_town',
                 'postal_code_pattern' => 'GIR ?0AA|(?:(?:AB|AL|B|BA|BB|BD|BF|BH|BL|BN|BR|BS|BT|BX|CA|CB|CF|CH|CM|CO|CR|CT|CV|CW|DA|DD|DE|DG|DH|DL|DN|DT|DY|E|EC|EH|EN|EX|FK|FY|G|GL|GY|GU|HA|HD|HG|HP|HR|HS|HU|HX|IG|IM|IP|IV|JE|KA|KT|KW|KY|L|LA|LD|LE|LL|LN|LS|LU|M|ME|MK|ML|N|NE|NG|NN|NP|NR|NW|OL|OX|PA|PE|PH|PL|PO|PR|RG|RH|RM|S|SA|SE|SG|SK|SL|SM|SN|SO|SP|SR|SS|ST|SW|SY|TA|TD|TF|TN|TQ|TR|TS|TW|UB|W|WA|WC|WD|WF|WN|WR|WS|WV|YO|ZE)(?:\d[\dA-Z]? ?\d[ABD-HJLN-UW-Z]{2}))|BFPO ?\d{1,4}',
+                'postal_code_example' => 'EC1Y 8SY',
             ],
             'GE' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '0101',
             ],
             'GF' => [
                 'format' => "%organization\n%givenName %familyName\n%addressLine1\n%addressLine2\n%postalCode %locality %sortingCode",
@@ -495,6 +549,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'addressLine2', 'locality', 'sortingCode',
                 ],
                 'postal_code_pattern' => '9[78]3\d{2}',
+                'postal_code_example' => '97300',
             ],
             'GG' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\nGUERNSEY\n%postalCode",
@@ -505,6 +560,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => 'GY\d[\dA-Z]? ?\d[ABD-HJLN-UW-Z]{2}',
+                'postal_code_example' => 'GY1 1AA',
             ],
             'GI' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\nGIBRALTAR\n%postalCode",
@@ -512,6 +568,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1',
                 ],
                 'postal_code_pattern' => 'GX11 1AA',
+                'postal_code_example' => 'GX11 1AA',
             ],
             'GL' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
@@ -519,10 +576,12 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '39\d{2}',
+                'postal_code_example' => '3900',
             ],
             'GN' => [
                 'format' => "%givenName %familyName\n%organization\n%postalCode %addressLine1\n%addressLine2 %locality",
                 'postal_code_pattern' => '\d{3}',
+                'postal_code_example' => '001',
             ],
             'GP' => [
                 'format' => "%organization\n%givenName %familyName\n%addressLine1\n%addressLine2\n%postalCode %locality %sortingCode",
@@ -533,6 +592,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'addressLine2', 'locality', 'sortingCode',
                 ],
                 'postal_code_pattern' => '9[78][01]\d{2}',
+                'postal_code_example' => '97100',
             ],
             'GR' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
@@ -540,6 +600,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '\d{3} ?\d{2}',
+                'postal_code_example' => '151 24',
             ],
             'GS' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n\n%locality\n%postalCode",
@@ -550,10 +611,12 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => 'SIQQ 1ZZ',
+                'postal_code_example' => 'SIQQ 1ZZ',
             ],
             'GT' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode- %locality",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '09001',
             ],
             'GU' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %postalCode",
@@ -565,10 +628,12 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 ],
                 'postal_code_type' => 'zip',
                 'postal_code_pattern' => '(969(?:[12]\d|3[12]))(?:[ \-](\d{4}))?',
+                'postal_code_example' => '96910',
             ],
             'GW' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '1000',
             ],
             'HK' => [
                 'locale' => 'zh-Hant',
@@ -590,6 +655,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'administrativeArea',
                 ],
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '7050',
             ],
             'HN' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality, %administrativeArea\n%postalCode",
@@ -597,15 +663,18 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'administrativeArea',
                 ],
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '31301',
             ],
             'HR' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '10000',
                 'postal_code_prefix' => 'HR-',
             ],
             'HT' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '6120',
                 'postal_code_prefix' => 'HT',
             ],
             'HU' => [
@@ -617,6 +686,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'addressLine2', 'locality', 'familyName', 'additionalName', 'givenName', 'organization',
                 ],
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '1037',
             ],
             'ID' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%administrativeArea %postalCode",
@@ -624,6 +694,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'administrativeArea',
                 ],
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '40115',
                 'subdivision_depth' => 1,
             ],
             'IE' => [
@@ -632,11 +703,13 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 'dependent_locality_type' => 'townland',
                 'postal_code_type' => 'eircode',
                 'postal_code_pattern' => '[\dA-Z]{3} ?[\dA-Z]{4}',
+                'postal_code_example' => 'A65 F4E2',
                 'subdivision_depth' => 1,
             ],
             'IL' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %postalCode",
                 'postal_code_pattern' => '\d{5}(?:\d{2})?',
+                'postal_code_example' => '9614303',
             ],
             'IM' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%postalCode",
@@ -647,6 +720,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => 'IM\d[\dA-Z]? ?\d[ABD-HJLN-UW-Z]{2}',
+                'postal_code_example' => 'IM2 1AA',
             ],
             'IN' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %postalCode\n%administrativeArea",
@@ -656,6 +730,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 'administrative_area_type' => 'state',
                 'postal_code_type' => 'pin',
                 'postal_code_pattern' => '\d{6}',
+                'postal_code_example' => '110034',
                 'subdivision_depth' => 1,
             ],
             'IO' => [
@@ -667,6 +742,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => 'BBND 1ZZ',
+                'postal_code_example' => 'BBND 1ZZ',
             ],
             'IQ' => [
                 'format' => "%organization\n%givenName %familyName\n%addressLine1\n%addressLine2\n%locality, %administrativeArea\n%postalCode",
@@ -677,16 +753,19 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'administrativeArea',
                 ],
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '31001',
             ],
             'IR' => [
                 'format' => "%organization\n%givenName %familyName\n%administrativeArea\n%locality, %dependentLocality\n%addressLine1\n%addressLine2\n%postalCode",
                 'dependent_locality_type' => 'neighborhood',
                 'postal_code_pattern' => '\d{5}-?\d{5}',
+                'postal_code_example' => '11936-12345',
                 'subdivision_depth' => 1,
             ],
             'IS' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{3}',
+                'postal_code_example' => '320',
             ],
             'IT' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality %administrativeArea",
@@ -697,6 +776,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'administrativeArea',
                 ],
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '00144',
                 'subdivision_depth' => 1,
             ],
             'JE' => [
@@ -708,6 +788,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => 'JE\d[\dA-Z]? ?\d[ABD-HJLN-UW-Z]{2}',
+                'postal_code_example' => 'JE1 1AA',
             ],
             'JM' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%administrativeArea %sortingCode",
@@ -720,32 +801,37 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
             'JO' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %postalCode",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '11937',
             ],
             'JP' => [
                 'locale' => 'ja',
-                'format' => "%familyName %givenName\n%organization\n%addressLine1\n%addressLine2\n%locality, %administrativeArea\n%postalCode",
-                'local_format' => "〒%postalCode\n%administrativeArea%locality\n%addressLine1\n%addressLine2\n%organization\n%familyName %givenName",
+                'format' => "%familyName %givenName\n%organization\n%addressLine1\n%addressLine2, %administrativeArea\n%postalCode",
+                'local_format' => "〒%postalCode\n%administrativeArea\n%addressLine1\n%addressLine2\n%organization\n%familyName %givenName",
                 'required_fields' => [
-                    'addressLine1', 'locality', 'administrativeArea', 'postalCode',
+                    'addressLine1', 'administrativeArea', 'postalCode',
                 ],
                 'uppercase_fields' => [
                     'administrativeArea',
                 ],
                 'administrative_area_type' => 'prefecture',
                 'postal_code_pattern' => '\d{3}-?\d{4}',
+                'postal_code_example' => '154-0023',
                 'subdivision_depth' => 1,
             ],
             'KE' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%postalCode",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '20100',
             ],
             'KG' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{6}',
+                'postal_code_example' => '720001',
             ],
             'KH' => [
                 'format' => "%familyName %givenName\n%organization\n%addressLine1\n%addressLine2\n%locality %postalCode",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '12203',
             ],
             'KI' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%administrativeArea\n%locality",
@@ -786,11 +872,13 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 'administrative_area_type' => 'do_si',
                 'dependent_locality_type' => 'district',
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '03051',
                 'subdivision_depth' => 3,
             ],
             'KW' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '54541',
             ],
             'KY' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%administrativeArea %postalCode",
@@ -799,19 +887,23 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 ],
                 'administrative_area_type' => 'island',
                 'postal_code_pattern' => 'KY\d-\d{4}',
+                'postal_code_example' => 'KY1-1100',
                 'subdivision_depth' => 1,
             ],
             'KZ' => [
                 'format' => "%postalCode\n%administrativeArea\n%locality\n%addressLine1\n%addressLine2\n%organization\n%givenName %familyName",
                 'postal_code_pattern' => '\d{6}',
+                'postal_code_example' => '040900',
             ],
             'LA' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '01160',
             ],
             'LB' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %postalCode",
                 'postal_code_pattern' => '(?:\d{4})(?: ?(?:\d{4}))?',
+                'postal_code_example' => '2038 3054',
             ],
             'LI' => [
                 'format' => "%organization\n%givenName %familyName\n%addressLine1\n%addressLine2\n%postalCode %locality",
@@ -819,19 +911,23 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '948[5-9]|949[0-8]',
+                'postal_code_example' => '9496',
                 'postal_code_prefix' => 'FL-',
             ],
             'LK' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%postalCode",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '20000',
             ],
             'LR' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '1000',
             ],
             'LS' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %postalCode",
                 'postal_code_pattern' => '\d{3}',
+                'postal_code_example' => '100',
             ],
             'LT' => [
                 'format' => "%organization\n%givenName %familyName\n%addressLine1\n%addressLine2\n%postalCode %locality %administrativeArea",
@@ -840,6 +936,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 ],
                 'administrative_area_type' => 'county',
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '04340',
                 'postal_code_prefix' => 'LT-',
             ],
             'LU' => [
@@ -848,6 +945,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '4750',
                 'postal_code_prefix' => 'L-',
             ],
             'LV' => [
@@ -856,24 +954,29 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => 'LV-\d{4}',
+                'postal_code_example' => 'LV-1073',
             ],
             'MA' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '53000',
             ],
             'MC' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality %sortingCode",
                 'postal_code_pattern' => '980\d{2}',
+                'postal_code_example' => '98000',
                 'postal_code_prefix' => 'MC-',
             ],
             'MD' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '2012',
                 'postal_code_prefix' => 'MD-',
             ],
             'ME' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '8\d{4}',
+                'postal_code_example' => '81257',
             ],
             'MF' => [
                 'format' => "%organization\n%givenName %familyName\n%addressLine1\n%addressLine2\n%postalCode %locality %sortingCode",
@@ -884,10 +987,12 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'addressLine2', 'locality', 'sortingCode',
                 ],
                 'postal_code_pattern' => '9[78][01]\d{2}',
+                'postal_code_example' => '97100',
             ],
             'MG' => [
                 'format' => "%familyName %givenName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{3}',
+                'postal_code_example' => '501',
             ],
             'MH' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %administrativeArea %postalCode",
@@ -900,18 +1005,22 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 'administrative_area_type' => 'state',
                 'postal_code_type' => 'zip',
                 'postal_code_pattern' => '(969[67]\d)(?:[ \-](\d{4}))?',
+                'postal_code_example' => '96960',
             ],
             'MK' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '1314',
             ],
             'MM' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality, %postalCode",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '11181',
             ],
             'MN' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%administrativeArea %postalCode",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '65030',
             ],
             'MO' => [
                 'locale' => 'zh-Hans',
@@ -932,6 +1041,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 'administrative_area_type' => 'state',
                 'postal_code_type' => 'zip',
                 'postal_code_pattern' => '(9695[012])(?:[ \-](\d{4}))?',
+                'postal_code_example' => '96950',
             ],
             'MQ' => [
                 'format' => "%organization\n%givenName %familyName\n%addressLine1\n%addressLine2\n%postalCode %locality %sortingCode",
@@ -942,6 +1052,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'addressLine2', 'locality', 'sortingCode',
                 ],
                 'postal_code_pattern' => '9[78]2\d{2}',
+                'postal_code_example' => '97220',
             ],
             'MR' => [
                 'uppercase_fields' => [
@@ -954,6 +1065,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '[A-Z]{3} ?\d{2,4}',
+                'postal_code_example' => 'NXR 01',
             ],
             'MU' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode\n%locality",
@@ -961,10 +1073,12 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '\d{3}(?:\d{2}|[A-Z]{2}\d{3})',
+                'postal_code_example' => '42602',
             ],
             'MV' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %postalCode",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '20026',
             ],
             'MW' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %sortingCode",
@@ -980,6 +1094,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 'administrative_area_type' => 'state',
                 'dependent_locality_type' => 'neighborhood',
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '02860',
                 'subdivision_depth' => 1,
             ],
             'MY' => [
@@ -993,12 +1108,19 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 'administrative_area_type' => 'state',
                 'dependent_locality_type' => 'village_township',
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '43000',
                 'subdivision_depth' => 1,
             ],
             'MZ' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality%administrativeArea",
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '1102',
                 'subdivision_depth' => 1,
+            ],
+            'NA' => [
+                'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%localityn%postalCode",
+                'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '10001',
             ],
             'NC' => [
                 'format' => "%organization\n%givenName %familyName\n%addressLine1\n%addressLine2\n%postalCode %locality %sortingCode",
@@ -1009,10 +1131,12 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'addressLine2', 'locality', 'sortingCode',
                 ],
                 'postal_code_pattern' => '988\d{2}',
+                'postal_code_example' => '98814',
             ],
             'NE' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '8001',
             ],
             'NF' => [
                 'format' => "%organization\n%givenName %familyName\n%addressLine1\n%addressLine2\n%locality %administrativeArea %postalCode",
@@ -1020,6 +1144,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'administrativeArea',
                 ],
                 'postal_code_pattern' => '2899',
+                'postal_code_example' => '2899',
             ],
             'NG' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%dependentLocality\n%locality %postalCode\n%administrativeArea",
@@ -1028,6 +1153,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 ],
                 'administrative_area_type' => 'state',
                 'postal_code_pattern' => '\d{6}',
+                'postal_code_example' => '930283',
                 'subdivision_depth' => 1,
             ],
             'NI' => [
@@ -1037,6 +1163,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 ],
                 'administrative_area_type' => 'department',
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '52000',
                 'subdivision_depth' => 1,
             ],
             'NL' => [
@@ -1045,6 +1172,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '\d{4} ?[A-Z]{2}',
+                'postal_code_example' => '1234 AB',
             ],
             'NO' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
@@ -1053,10 +1181,12 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 ],
                 'locality_type' => 'post_town',
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '0025',
             ],
             'NP' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %postalCode",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '44601',
             ],
             'NR' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%administrativeArea",
@@ -1072,10 +1202,12 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '6001',
             ],
             'OM' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode\n%locality",
                 'postal_code_pattern' => '(?:PC )?\d{3}',
+                'postal_code_example' => '133',
             ],
             'PA' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%administrativeArea",
@@ -1087,6 +1219,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %postalCode\n%administrativeArea",
                 'locality_type' => 'district',
                 'postal_code_pattern' => '(?:LIMA \d{1,2}|CALLAO 0?\d)|[0-2]\d{4}',
+                'postal_code_example' => 'LIMA 23',
                 'subdivision_depth' => 1,
             ],
             'PF' => [
@@ -1099,6 +1232,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 ],
                 'administrative_area_type' => 'island',
                 'postal_code_pattern' => '987\d{2}',
+                'postal_code_example' => '98709',
             ],
             'PG' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %postalCode %administrativeArea",
@@ -1106,15 +1240,18 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'administrativeArea',
                 ],
                 'postal_code_pattern' => '\d{3}',
+                'postal_code_example' => '111',
             ],
             'PH' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%dependentLocality, %locality\n%postalCode %administrativeArea",
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '1008',
                 'subdivision_depth' => 1,
             ],
             'PK' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality-%postalCode",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '44000',
             ],
             'PL' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
@@ -1122,6 +1259,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '\d{2}-\d{3}',
+                'postal_code_example' => '00-950',
             ],
             'PM' => [
                 'format' => "%organization\n%givenName %familyName\n%addressLine1\n%addressLine2\n%postalCode %locality %sortingCode",
@@ -1132,6 +1270,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'addressLine2', 'locality', 'sortingCode',
                 ],
                 'postal_code_pattern' => '9[78]5\d{2}',
+                'postal_code_example' => '97500',
             ],
             'PN' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%postalCode",
@@ -1142,6 +1281,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => 'PCRN 1ZZ',
+                'postal_code_example' => 'PCRN 1ZZ',
             ],
             'PR' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %postalCode",
@@ -1153,6 +1293,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 ],
                 'postal_code_type' => 'zip',
                 'postal_code_pattern' => '(00[679]\d{2})(?:[ \-](\d{4}))?',
+                'postal_code_example' => '00930',
                 'postal_code_prefix' => 'PR ',
             ],
             'PT' => [
@@ -1161,6 +1302,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '\d{4}-\d{3}',
+                'postal_code_example' => '2725-079',
             ],
             'PW' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %administrativeArea %postalCode",
@@ -1173,10 +1315,12 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 'administrative_area_type' => 'state',
                 'postal_code_type' => 'zip',
                 'postal_code_pattern' => '(969(?:39|40))(?:[ \-](\d{4}))?',
+                'postal_code_example' => '96940',
             ],
             'PY' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '1536',
             ],
             'QA' => [
                 'uppercase_fields' => [
@@ -1192,17 +1336,23 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'addressLine2', 'locality', 'sortingCode',
                 ],
                 'postal_code_pattern' => '9[78]4\d{2}',
+                'postal_code_example' => '97400',
             ],
             'RO' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
+                'required_fields' => [
+                    'addressLine1', 'locality', 'postalCode',
+                ],
                 'uppercase_fields' => [
                     'addressLine1', 'addressLine2', 'locality',
                 ],
                 'postal_code_pattern' => '\d{6}',
+                'postal_code_example' => '060274',
             ],
             'RS' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{5,6}',
+                'postal_code_example' => '106314',
             ],
             'RU' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%administrativeArea\n%postalCode",
@@ -1214,6 +1364,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 ],
                 'administrative_area_type' => 'oblast',
                 'postal_code_pattern' => '\d{6}',
+                'postal_code_example' => '247112',
                 'subdivision_depth' => 1,
             ],
             'RW' => [
@@ -1224,6 +1375,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
             'SA' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %postalCode",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '11564',
             ],
             'SC' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%administrativeArea",
@@ -1236,6 +1388,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%postalCode",
                 'locality_type' => 'district',
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '11042',
             ],
             'SE' => [
                 'format' => "%organization\n%givenName %familyName\n%addressLine1\n%addressLine2\n%postalCode %locality",
@@ -1244,6 +1397,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 ],
                 'locality_type' => 'post_town',
                 'postal_code_pattern' => '\d{3} ?\d{2}',
+                'postal_code_example' => '11455',
                 'postal_code_prefix' => 'SE-',
             ],
             'SG' => [
@@ -1252,6 +1406,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'postalCode',
                 ],
                 'postal_code_pattern' => '\d{6}',
+                'postal_code_example' => '546080',
             ],
             'SH' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%postalCode",
@@ -1262,10 +1417,12 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '(?:ASCN|STHL) 1ZZ',
+                'postal_code_example' => 'STHL 1ZZ',
             ],
             'SI' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '4000',
                 'postal_code_prefix' => 'SI-',
             ],
             'SJ' => [
@@ -1275,6 +1432,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 ],
                 'locality_type' => 'post_town',
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '9170',
             ],
             'SK' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
@@ -1282,6 +1440,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '\d{3} ?\d{2}',
+                'postal_code_example' => '010 01',
             ],
             'SM' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
@@ -1289,10 +1448,12 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'postalCode',
                 ],
                 'postal_code_pattern' => '4789\d',
+                'postal_code_example' => '47890',
             ],
             'SN' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '12500',
             ],
             'SO' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality, %administrativeArea %postalCode",
@@ -1303,6 +1464,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'addressLine2', 'locality', 'administrativeArea',
                 ],
                 'postal_code_pattern' => '[A-Z]{2} ?\d{5}',
+                'postal_code_example' => 'JH 09010',
                 'subdivision_depth' => 1,
             ],
             'SR' => [
@@ -1321,6 +1483,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'administrativeArea', 'postalCode',
                 ],
                 'postal_code_pattern' => 'CP [1-3][1-7][0-2]\d',
+                'postal_code_example' => 'CP 1101',
                 'subdivision_depth' => 1,
             ],
             'SY' => [
@@ -1332,10 +1495,12 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'addressLine2', 'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '[HLMS]\d{3}',
+                'postal_code_example' => 'H100',
             ],
             'TA' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%postalCode",
                 'postal_code_pattern' => 'TDCU 1ZZ',
+                'postal_code_example' => 'TDCU 1ZZ',
             ],
             'TC' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%postalCode",
@@ -1346,6 +1511,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => 'TKCA 1ZZ',
+                'postal_code_example' => 'TKCA 1ZZ',
             ],
             'TH' => [
                 'locale' => 'th',
@@ -1355,19 +1521,23 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'administrativeArea',
                 ],
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '10150',
                 'subdivision_depth' => 1,
             ],
             'TJ' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{6}',
+                'postal_code_example' => '735450',
             ],
             'TM' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{6}',
+                'postal_code_example' => '744000',
             ],
             'TN' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '1002',
             ],
             'TR' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality/%administrativeArea",
@@ -1376,6 +1546,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 ],
                 'locality_type' => 'district',
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '01960',
                 'subdivision_depth' => 1,
             ],
             'TV' => [
@@ -1395,11 +1566,13 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 ],
                 'administrative_area_type' => 'county',
                 'postal_code_pattern' => '\d{3}(?:\d{2})?',
+                'postal_code_example' => '104',
                 'subdivision_depth' => 2,
             ],
             'TZ' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{4,5}',
+                'postal_code_example' => '6090',
             ],
             'UA' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%administrativeArea\n%postalCode",
@@ -1408,6 +1581,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 ],
                 'administrative_area_type' => 'oblast',
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '15432',
                 'subdivision_depth' => 1,
             ],
             'UM' => [
@@ -1421,6 +1595,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 'administrative_area_type' => 'state',
                 'postal_code_type' => 'zip',
                 'postal_code_pattern' => '96898',
+                'postal_code_example' => '96898',
             ],
             'US' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality, %administrativeArea %postalCode",
@@ -1433,6 +1608,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 'administrative_area_type' => 'state',
                 'postal_code_type' => 'zip',
                 'postal_code_pattern' => '(\d{5})(?:[ \-](\d{4}))?',
+                'postal_code_example' => '95014',
                 'subdivision_depth' => 1,
             ],
             'UY' => [
@@ -1441,6 +1617,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'administrativeArea',
                 ],
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '11600',
                 'subdivision_depth' => 1,
             ],
             'UZ' => [
@@ -1449,14 +1626,17 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'locality', 'administrativeArea',
                 ],
                 'postal_code_pattern' => '\d{6}',
+                'postal_code_example' => '702100',
             ],
             'VA' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '00120',
+                'postal_code_example' => '00120',
             ],
             'VC' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %postalCode",
                 'postal_code_pattern' => 'VC\d{4}',
+                'postal_code_example' => 'VC0100',
             ],
             'VE' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %postalCode, %administrativeArea",
@@ -1468,6 +1648,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 ],
                 'administrative_area_type' => 'state',
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '1010',
                 'subdivision_depth' => 1,
             ],
             'VG' => [
@@ -1476,6 +1657,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1',
                 ],
                 'postal_code_pattern' => 'VG\d{4}',
+                'postal_code_example' => 'VG1110',
             ],
             'VI' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality %administrativeArea %postalCode",
@@ -1488,10 +1670,12 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 'administrative_area_type' => 'state',
                 'postal_code_type' => 'zip',
                 'postal_code_pattern' => '(008(?:(?:[0-4]\d)|(?:5[01])))(?:[ \-](\d{4}))?',
+                'postal_code_example' => '00802-1222',
             ],
             'VN' => [
                 'format' => "%familyName %givenName\n%organization\n%addressLine1\n%addressLine2\n%locality\n%administrativeArea %postalCode",
                 'postal_code_pattern' => '\d{5}\d?',
+                'postal_code_example' => '70010',
                 'subdivision_depth' => 1,
             ],
             'WF' => [
@@ -1503,10 +1687,12 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'addressLine2', 'locality', 'sortingCode',
                 ],
                 'postal_code_pattern' => '986\d{2}',
+                'postal_code_example' => '98600',
             ],
             'XK' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '[1-7]\d{4}',
+                'postal_code_example' => '10000',
             ],
             'YT' => [
                 'format' => "%organization\n%givenName %familyName\n%addressLine1\n%addressLine2\n%postalCode %locality %sortingCode",
@@ -1517,6 +1703,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'addressLine2', 'locality', 'sortingCode',
                 ],
                 'postal_code_pattern' => '976\d{2}',
+                'postal_code_example' => '97600',
             ],
             'ZA' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%dependentLocality\n%locality\n%postalCode",
@@ -1524,10 +1711,12 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                     'addressLine1', 'locality', 'postalCode',
                 ],
                 'postal_code_pattern' => '\d{4}',
+                'postal_code_example' => '0083',
             ],
             'ZM' => [
                 'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%postalCode %locality",
                 'postal_code_pattern' => '\d{5}',
+                'postal_code_example' => '50100',
             ],
         ];
         // @codingStandardsIgnoreEnd


### PR DESCRIPTION
## Problem/Motivation
There are many scenarios in which the postal code validation return ambiguous error messages. It might be useful to provide some additional context through a valid example. Google provides a list of valid postal code examples under the `zipex` property. As a first step to improve postal code validation, we would need to include this property in the addressing resources.

- [ ] Updated `generate_address_data.php` to include `zipex` on both country and subdivision level
- [ ] Added property `postalCodeExample` and getter to `AddressFormat` class

Closes #127 