### PR TITLE
Add PHP 7.4 support and drop support for PHP 7.0 (EOL)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: php
 
 php:
+  - 7.4
   - 7.3
   - 7.2
   - 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ php:
   - 7.3
   - 7.2
   - 7.1
-  - 7.0
 
 install:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
   - composer install
 
 script:
-  - ./vendor/bin/phpunit -c ./phpunit.xml --coverage-text
+  - XDEBUG_MODE=coverage ./vendor/bin/phpunit -c ./phpunit.xml --coverage-text
   - ./vendor/bin/phpcs --standard=phpcs.xml src -s
   - ./vendor/bin/phpcs --standard=phpcs.xml tests -s
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ addressing
 
 [![Build Status](https://travis-ci.org/commerceguys/addressing.svg?branch=master)](https://travis-ci.org/commerceguys/addressing)
 
-A PHP 7.0+ addressing library, powered by CLDR and Google's address data.
+A PHP 7.1+ addressing library, powered by CLDR and Google's address data.
 
 Manipulates postal addresses, meant to identify a precise recipient location for shipping or billing purposes.
 

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "doctrine/collections": "~1.0"
     },
     "require-dev": {
-        "symfony/validator": "^3.4",
+        "symfony/validator": "^4.4",
         "phpunit/phpunit": "^6.0",
         "mikey179/vfsstream": "1.*",
         "squizlabs/php_codesniffer": "3.*"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     },
     "require-dev": {
         "symfony/validator": "^4.4",
-        "phpunit/phpunit": "^6.0",
+        "phpunit/phpunit": "^7.5",
         "mikey179/vfsstream": "1.*",
         "squizlabs/php_codesniffer": "3.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "keywords": ["postal", "address", "internationalization", "localization"],
     "license": "MIT",
     "require": {
-        "php": ">=7.0.8",
+        "php": ">=7.1.3",
         "doctrine/collections": "~1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         "symfony/validator": "^3.4",
         "phpunit/phpunit": "^6.0",
         "mikey179/vfsstream": "1.*",
-        "squizlabs/php_codesniffer": "2.*"
+        "squizlabs/php_codesniffer": "3.*"
     },
     "suggest": {
         "symfony/validator": "to validate addresses"

--- a/src/UpdateHelper.php
+++ b/src/UpdateHelper.php
@@ -16,7 +16,7 @@ class UpdateHelper
      *
      * @var array
      */
-    static protected $subdivisionUpdateMap = [];
+    protected static $subdivisionUpdateMap = [];
 
     /**
      * Splits the recipient into givenName and familyName fields.


### PR DESCRIPTION
@bojanz Thank you for your continued efforts on this package! 

I've taken the liberty to add support for PHP7.4 and drop support for PHP 7.0 and PHP 7.1 which have been EOL for [at least one year now](https://www.php.net/eol.php).