### PR TITLE
Remove Jarvis Bay from Australias state list

### DIFF
--- a/resources/subdivision/AU.json
+++ b/resources/subdivision/AU.json
@@ -6,10 +6,6 @@
 			"iso_code": "AU-ACT",
 			"postal_code_pattern": "29|2540|260|261[0-8]|02|2620"
 		},
-		"JBT": {
-			"name": "Jervis Bay Territory",
-			"postal_code_pattern": "2540"
-		},
 		"NSW": {
 			"name": "New South Wales",
 			"iso_code": "AU-NSW",


### PR DESCRIPTION
As nice as Jervis Bay is as a place, it isnt a state or territory in Australia.  Please can we have this removed. thanks.