### PR TITLE
Change province > region (France country)

### DIFF
--- a/src/AddressInterface.php
+++ b/src/AddressInterface.php
@@ -33,7 +33,7 @@ interface AddressInterface
     /**
      * Gets the administrative area.
      *
-     * Called the "state" in the United States, "province" in France and Italy,
+     * Called the "state" in the United States, "region" in France, "province" in Italy,
      * "county" in Great Britain, "prefecture" in Japan, etc.
      *
      * @return string The administrative area. A subdivision code if there


### PR DESCRIPTION
The word "region" (région in French) is more suitable for the administrative area field in France.

> The province is a natural region.
> The region is an administrative entity.

Also, Google Maps API's provide a "region" for the "administrative_area_level_1" field. (@see https://developers.google.com/maps/documentation/javascript/geocoding?hl=fr#GeocodingAddressTypes)

Sources:
* https://www.lefrancaisdesaffaires.fr/wp-content/uploads/2016/05/province_et_region.pdf
* https://mediateur.radiofrance.com/infos/en-province-en-region/#:~:text=La%20locution%20la%20plus%20commune,parfait%20de%20%C2%AB%20en%20province%20%C2%BB.&text=En%20province%2C%20on%20a%20la,ne%20pas%20%C2%AB%20faire%20Paris%20%C2%BB.