### PR TITLE
Drop support of php < 7.3, upgrade to phunit 9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 vendor/
 composer.lock
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ sudo: false
 language: php
 
 php:
+  - 8.1
+  - 8.0
   - 7.4
   - 7.3
-  - 7.2
-  - 7.1
 
 install:
   - composer self-update

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ addressing
 
 [![Build Status](https://travis-ci.org/commerceguys/addressing.svg?branch=master)](https://travis-ci.org/commerceguys/addressing)
 
-A PHP 7.1+ addressing library, powered by CLDR and Google's address data.
+A PHP 7.3+ addressing library, powered by CLDR and Google's address data.
 
 Manipulates postal addresses, meant to identify a precise recipient location for shipping or billing purposes.
 

--- a/composer.json
+++ b/composer.json
@@ -5,14 +5,15 @@
     "keywords": ["postal", "address", "internationalization", "localization"],
     "license": "MIT",
     "require": {
-        "php": ">=7.1.3",
+        "php": ">=7.3",
         "doctrine/collections": "~1.0"
     },
     "require-dev": {
-        "symfony/validator": "^4.4",
-        "phpunit/phpunit": "^7.5",
+        "symfony/validator": "^4.4 || ^5.4",
+        "phpunit/phpunit": "^9.5",
         "mikey179/vfsstream": "1.*",
-        "squizlabs/php_codesniffer": "3.*"
+        "squizlabs/php_codesniffer": "3.*",
+        "ext-json": "*"
     },
     "suggest": {
         "symfony/validator": "to validate addresses"

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
          backupStaticAttributes="false"
          colors="true"
          convertErrorsToExceptions="true"
@@ -8,16 +8,15 @@
          convertWarningsToExceptions="true"
          stopOnFailure="false"
          bootstrap="vendor/autoload.php"
->
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./src/</directory>
+    </include>
+  </coverage>
   <testsuites>
     <testsuite name="CommerceGuys Addressing Test Suite">
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
-
-  <filter>
-    <whitelist>
-      <directory suffix=".php">./src/</directory>
-    </whitelist>
-  </filter>
 </phpunit>

--- a/tests/AbstractEnumTest.php
+++ b/tests/AbstractEnumTest.php
@@ -46,23 +46,21 @@ final class AbstractEnumTest extends TestCase
 
     /**
      * @covers ::assertExists
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage "invalid" is not a valid PatternType value.
      */
     public function testAssertExists()
     {
+        $this->expectExceptionMessage("\"invalid\" is not a valid PatternType value.");
+        $this->expectException(\InvalidArgumentException::class);
         $result = PatternType::assertExists('invalid');
     }
 
     /**
      * @covers ::assertAllExist
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage "invalid" is not a valid PatternType value.
      */
     public function testAssertAllExist()
     {
+        $this->expectExceptionMessage("\"invalid\" is not a valid PatternType value.");
+        $this->expectException(\InvalidArgumentException::class);
         $result = PatternType::assertAllExist(['start', 'invalid']);
     }
 }

--- a/tests/AddressFormat/AddressFormatTest.php
+++ b/tests/AddressFormat/AddressFormatTest.php
@@ -18,10 +18,11 @@ final class AddressFormatTest extends TestCase
     /**
      * @covers ::__construct
      *
-     * @expectedException \InvalidArgumentException
+     *
      */
     public function testMissingProperty()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $definition = [
             'country_code' => 'US',
         ];
@@ -31,10 +32,11 @@ final class AddressFormatTest extends TestCase
     /**
      * @covers ::__construct
      *
-     * @expectedException \InvalidArgumentException
+     *
      */
     public function testInvalidSubdivision()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $definition = [
             'country_code' => 'US',
             'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%dependentLocality",

--- a/tests/AddressFormat/FieldOverridesTest.php
+++ b/tests/AddressFormat/FieldOverridesTest.php
@@ -15,10 +15,11 @@ final class FieldOverridesTest extends TestCase
     /**
      * @covers ::__construct
      *
-     * @expectedException \InvalidArgumentException
+     *
      */
     public function testInvalidField()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $definition = [
             'INVALID_FIELD' => FieldOverride::HIDDEN,
         ];
@@ -28,10 +29,11 @@ final class FieldOverridesTest extends TestCase
     /**
      * @covers ::__construct
      *
-     * @expectedException \InvalidArgumentException
+     *
      */
     public function testInvalidOverride()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $definition = [
             AddressField::POSTAL_CODE => 'INVALID',
         ];

--- a/tests/Country/CountryRepositoryTest.php
+++ b/tests/Country/CountryRepositoryTest.php
@@ -46,7 +46,10 @@ final class CountryRepositoryTest extends TestCase
         // Instantiate the country repository and confirm that the definition path
         // was properly set.
         $countryRepository = new CountryRepository('de', 'en', 'vfs://resources/country/');
-        $definitionPath = $this->getObjectAttribute($countryRepository, 'definitionPath');
+
+        $reflected_constraint = (new \ReflectionObject($countryRepository))->getProperty('definitionPath');
+        $reflected_constraint->setAccessible(TRUE);
+        $definitionPath = $reflected_constraint->getValue($countryRepository);
         $this->assertEquals('vfs://resources/country/', $definitionPath);
 
         return $countryRepository;
@@ -92,11 +95,12 @@ final class CountryRepositoryTest extends TestCase
      * @covers ::loadDefinitions
      *
      * @uses \CommerceGuys\Addressing\Locale
-     * @expectedException \CommerceGuys\Addressing\Exception\UnknownCountryException
+     *
      * @depends testConstructor
      */
     public function testGetInvalidCountry($countryRepository)
     {
+        $this->expectException(\CommerceGuys\Addressing\Exception\UnknownCountryException::class);
         $countryRepository->get('INVALID');
     }
 

--- a/tests/Formatter/DefaultFormatterTest.php
+++ b/tests/Formatter/DefaultFormatterTest.php
@@ -4,9 +4,12 @@ namespace CommerceGuys\Addressing\Tests\Formatter;
 
 use CommerceGuys\Addressing\Address;
 use CommerceGuys\Addressing\AddressFormat\AddressFormatRepository;
+use CommerceGuys\Addressing\AddressFormat\AddressFormatRepositoryInterface;
 use CommerceGuys\Addressing\Country\CountryRepository;
+use CommerceGuys\Addressing\Country\CountryRepositoryInterface;
 use CommerceGuys\Addressing\Formatter\DefaultFormatter;
 use CommerceGuys\Addressing\Subdivision\SubdivisionRepository;
+use CommerceGuys\Addressing\Subdivision\SubdivisionRepositoryInterface;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -45,7 +48,7 @@ final class DefaultFormatterTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->addressFormatRepository = new AddressFormatRepository();
         $this->countryRepository = new CountryRepository();
@@ -56,29 +59,41 @@ final class DefaultFormatterTest extends TestCase
     /**
      * @covers ::__construct
      */
-    public function testConstructor()
+    public function testConstructor(): void
     {
         $formatter = new DefaultFormatter($this->addressFormatRepository, $this->countryRepository, $this->subdivisionRepository);
-        $this->assertEquals($this->addressFormatRepository, $this->getObjectAttribute($formatter, 'addressFormatRepository'));
-        $this->assertEquals($this->countryRepository, $this->getObjectAttribute($formatter, 'countryRepository'));
-        $this->assertEquals($this->subdivisionRepository, $this->getObjectAttribute($formatter, 'subdivisionRepository'));
+
+        $reflected_constraint = (new \ReflectionObject($formatter))->getProperty('addressFormatRepository');
+        $reflected_constraint->setAccessible(TRUE);
+        $constraint = $reflected_constraint->getValue($formatter);
+        $this->assertInstanceOf(AddressFormatRepository::class, $constraint);
+
+        $reflected_constraint = (new \ReflectionObject($formatter))->getProperty('countryRepository');
+        $reflected_constraint->setAccessible(TRUE);
+        $constraint = $reflected_constraint->getValue($formatter);
+        $this->assertInstanceOf(CountryRepository::class, $constraint);
+
+        $reflected_constraint = (new \ReflectionObject($formatter))->getProperty('subdivisionRepository');
+        $reflected_constraint->setAccessible(TRUE);
+        $constraint = $reflected_constraint->getValue($formatter);
+        $this->assertInstanceOf(SubdivisionRepository::class, $constraint);
     }
 
     /**
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
     public function testUnrecognizedOption()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $formatter = new DefaultFormatter($this->addressFormatRepository, $this->countryRepository, $this->subdivisionRepository, ['unrecognized' => '123']);
     }
 
     /**
      * @covers ::__construct
-     * @expectedException \InvalidArgumentException
      */
     public function testInvalidOption()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $formatter = new DefaultFormatter($this->addressFormatRepository, $this->countryRepository, $this->subdivisionRepository, ['html' => 'INVALID']);
     }
 
@@ -272,11 +287,8 @@ final class DefaultFormatterTest extends TestCase
 
     /**
      * Asserts that the formatted address is valid.
-     *
-     * @param array  $expectedLines
-     * @param string $formattedAddress
      */
-    protected function assertFormattedAddress(array $expectedLines, $formattedAddress)
+    protected function assertFormattedAddress(array $expectedLines, string $formattedAddress)
     {
         $expectedLines = implode("\n", $expectedLines);
         $this->assertEquals($expectedLines, $formattedAddress);

--- a/tests/Formatter/PostalLabelFormatterTest.php
+++ b/tests/Formatter/PostalLabelFormatterTest.php
@@ -45,7 +45,7 @@ final class PostalLabelFormatterTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->addressFormatRepository = new AddressFormatRepository();
         $this->countryRepository = new CountryRepository();
@@ -56,10 +56,11 @@ final class PostalLabelFormatterTest extends TestCase
     /**
      * @covers ::format
      *
-     * @expectedException \InvalidArgumentException
+     *
      */
     public function testMissingOriginCountryCode()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $address = new Address();
         $this->formatter->format($address);
     }

--- a/tests/Subdivision/LazySubdivisionCollectionTest.php
+++ b/tests/Subdivision/LazySubdivisionCollectionTest.php
@@ -18,7 +18,7 @@ final class LazySubdivisionCollectionTest extends TestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->collection = new LazySubdivisionCollection(['BR', 'Porto Acre']);
     }
@@ -29,7 +29,10 @@ final class LazySubdivisionCollectionTest extends TestCase
     public function testConstructor()
     {
         $collection = new LazySubdivisionCollection(['BR', 'Porto Acre']);
-        $this->assertEquals(['BR', 'Porto Acre'], $this->getObjectAttribute($collection, 'parents'));
+
+        $reflected_constraint = (new \ReflectionObject($collection))->getProperty('parents');
+        $reflected_constraint->setAccessible(TRUE);
+        $this->assertEquals(['BR', 'Porto Acre'], $reflected_constraint->getValue($collection));
     }
 
     /**

--- a/tests/Subdivision/SubdivisionRepositoryTest.php
+++ b/tests/Subdivision/SubdivisionRepositoryTest.php
@@ -71,7 +71,10 @@ final class SubdivisionRepositoryTest extends TestCase
         // Instantiate the subdivision repository and confirm that the
         // definition path was properly set.
         $subdivisionRepository = new SubdivisionRepository(null, 'vfs://resources/subdivision/');
-        $definitionPath = $this->getObjectAttribute($subdivisionRepository, 'definitionPath');
+
+        $reflected_constraint = (new \ReflectionObject($subdivisionRepository))->getProperty('definitionPath');
+        $reflected_constraint->setAccessible(TRUE);
+        $definitionPath = $reflected_constraint->getValue($subdivisionRepository);
         $this->assertEquals('vfs://resources/subdivision/', $definitionPath);
 
         return $subdivisionRepository;
@@ -149,13 +152,13 @@ final class SubdivisionRepositoryTest extends TestCase
         $this->assertCount(2, $subdivisions);
         $this->assertArrayHasKey('SC', $subdivisions);
         $this->assertArrayHasKey('SP', $subdivisions);
-        $this->assertEquals($subdivisions['SC']->getCode(), 'SC');
-        $this->assertEquals($subdivisions['SP']->getCode(), 'SP');
+        $this->assertEquals('SC', $subdivisions['SC']->getCode());
+        $this->assertEquals('SP', $subdivisions['SP']->getCode());
 
         $subdivisions = $subdivisionRepository->getAll(['BR', 'SC']);
         $this->assertCount(1, $subdivisions);
         $this->assertArrayHasKey('Abelardo Luz', $subdivisions);
-        $this->assertEquals($subdivisions['Abelardo Luz']->getCode(), 'Abelardo Luz');
+        $this->assertEquals('Abelardo Luz', $subdivisions['Abelardo Luz']->getCode());
     }
 
     /**

--- a/tests/Subdivision/SubdivisionTest.php
+++ b/tests/Subdivision/SubdivisionTest.php
@@ -14,11 +14,10 @@ final class SubdivisionTest extends TestCase
 {
     /**
      * @covers ::__construct
-     *
-     * @expectedException \InvalidArgumentException
      */
     public function testMissingProperty()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $definition = [
             'country_code' => 'US',
         ];

--- a/tests/Validator/Constraints/AddressFormatConstraintValidatorTest.php
+++ b/tests/Validator/Constraints/AddressFormatConstraintValidatorTest.php
@@ -23,7 +23,7 @@ final class AddressFormatConstraintValidatorTest extends ConstraintValidatorTest
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->constraint = new AddressFormatConstraint();
 
@@ -48,11 +48,10 @@ final class AddressFormatConstraintValidatorTest extends ConstraintValidatorTest
 
     /**
      * @covers \CommerceGuys\Addressing\Validator\Constraints\AddressFormatConstraintValidator
-     *
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
      */
     public function testInvalidValueType()
     {
+        $this->expectException(\Symfony\Component\Validator\Exception\UnexpectedTypeException::class);
         $this->validator->validate(new \stdClass(), $this->constraint);
     }
 
@@ -379,7 +378,7 @@ final class AddressFormatConstraintValidatorTest extends ConstraintValidatorTest
     }
 
     /**
-     * @covers CommerceGuys\Addressing\Validator\Constraints\AddressFormatConstraintValidator
+     * @covers \CommerceGuys\Addressing\Validator\Constraints\AddressFormatConstraintValidator
      */
     public function testJapan()
     {

--- a/tests/Validator/Constraints/CountryConstraintValidatorTest.php
+++ b/tests/Validator/Constraints/CountryConstraintValidatorTest.php
@@ -19,7 +19,7 @@ final class CountryConstraintValidatorTest extends ConstraintValidatorTestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->constraint = new CountryConstraint();
 
@@ -57,10 +57,11 @@ final class CountryConstraintValidatorTest extends ConstraintValidatorTestCase
     /**
      * @covers \CommerceGuys\Addressing\Validator\Constraints\CountryConstraintValidator
      *
-     * @expectedException \Symfony\Component\Validator\Exception\UnexpectedTypeException
+     *
      */
     public function testInvalidValueType()
     {
+        $this->expectException(\Symfony\Component\Validator\Exception\UnexpectedTypeException::class);
         $this->validator->validate(new \stdClass(), $this->constraint);
     }
 
@@ -87,7 +88,7 @@ final class CountryConstraintValidatorTest extends ConstraintValidatorTestCase
         $this->assertNoViolation();
     }
 
-    public function getValidCountries()
+    public function getValidCountries(): array
     {
         return [
             ['GB'],

--- a/tests/Zone/ZoneTerritoryTest.php
+++ b/tests/Zone/ZoneTerritoryTest.php
@@ -14,10 +14,11 @@ final class ZoneTerritoryTest extends TestCase
     /**
      * @covers ::__construct
      *
-     * @expectedException \InvalidArgumentException
+     *
      */
     public function testMissingProperty()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $territory = new ZoneTerritory([]);
     }
 

--- a/tests/Zone/ZoneTest.php
+++ b/tests/Zone/ZoneTest.php
@@ -14,10 +14,11 @@ final class ZoneTest extends TestCase
     /**
      * @covers ::__construct
      *
-     * @expectedException \InvalidArgumentException
+     *
      */
     public function testMissingProperty()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $definition = [
             'id' => 'test',
         ];
@@ -27,10 +28,11 @@ final class ZoneTest extends TestCase
     /**
      * @covers ::__construct
      *
-     * @expectedException \InvalidArgumentException
+     *
      */
     public function testInvalidTerritories()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $definition = [
             'id' => 'test',
             'label' => 'Test',


### PR DESCRIPTION
Hi,

only 2% of usage is Php < 7.3.
https://packagist.org/packages/commerceguys/addressing/php-stats#1.2

I suggest to move toward php  >= 7.3

Travis Test for 7.4, 8.0, 8.1 are adjusted.

Greetz