### PR TITLE
feat: add minimum version in composer.json, allow symfony6 validator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,13 +6,13 @@
     "license": "MIT",
     "require": {
         "php": ">=7.3",
-        "doctrine/collections": "~1.0"
+        "doctrine/collections": "^1.2"
     },
     "require-dev": {
-        "symfony/validator": "^4.4 || ^5.4",
+        "symfony/validator": "^4.4 || ^5.4 || ^6.0",
         "phpunit/phpunit": "^9.5",
-        "mikey179/vfsstream": "1.*",
-        "squizlabs/php_codesniffer": "3.*",
+        "mikey179/vfsstream": "^1.6.10",
+        "squizlabs/php_codesniffer": "^3.6",
         "ext-json": "*"
     },
     "suggest": {

--- a/tests/Validator/Constraints/AddressFormatConstraintValidatorTest.php
+++ b/tests/Validator/Constraints/AddressFormatConstraintValidatorTest.php
@@ -8,6 +8,7 @@ use CommerceGuys\Addressing\AddressFormat\FieldOverride;
 use CommerceGuys\Addressing\AddressFormat\FieldOverrides;
 use CommerceGuys\Addressing\Validator\Constraints\AddressFormatConstraint;
 use CommerceGuys\Addressing\Validator\Constraints\AddressFormatConstraintValidator;
+use Symfony\Component\Validator\Constraints\NotNull;
 use Symfony\Component\Validator\Test\ConstraintValidatorTestCase;
 
 /**
@@ -36,9 +37,22 @@ final class AddressFormatConstraintValidatorTest extends ConstraintValidatorTest
         $this->value = 'InvalidValue';
         $this->root = 'root';
         $this->propertyPath = '';
+
         $this->context = $this->createContext();
         $this->validator = $this->createValidator();
         $this->validator->initialize($this->context);
+
+        $this->defaultLocale = 'en';
+
+        $this->expectedViolations = [];
+        $this->call = 0;
+
+        $this->setDefaultTimezone('UTC');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreDefaultTimezone();
     }
 
     protected function createValidator()

--- a/tests/Validator/Constraints/CountryConstraintValidatorTest.php
+++ b/tests/Validator/Constraints/CountryConstraintValidatorTest.php
@@ -16,6 +16,7 @@ final class CountryConstraintValidatorTest extends ConstraintValidatorTestCase
      */
     protected $constraint;
 
+
     /**
      * {@inheritdoc}
      */
@@ -32,9 +33,22 @@ final class CountryConstraintValidatorTest extends ConstraintValidatorTestCase
         $this->value = 'InvalidValue';
         $this->root = 'root';
         $this->propertyPath = '';
+
         $this->context = $this->createContext();
         $this->validator = $this->createValidator();
         $this->validator->initialize($this->context);
+
+        $this->defaultLocale = 'en';
+
+        $this->expectedViolations = [];
+        $this->call = 0;
+
+        $this->setDefaultTimezone('UTC');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreDefaultTimezone();
     }
 
     protected function createValidator()


### PR DESCRIPTION
The minium versions are not checkedby travis
composer update --prefer-lowest

I updated them so test will pass.

Add support of symfony/validator v. 6.
Overriding the tearDown() is important. Otherwise $this->defaultLocale will have an error of used before initialized.