### PR TITLE
Add middle name to US addresses

### DIFF
--- a/src/AddressFormat/AddressFormatRepository.php
+++ b/src/AddressFormat/AddressFormatRepository.php
@@ -1431,7 +1431,7 @@ class AddressFormatRepository implements AddressFormatRepositoryInterface
                 'postal_code_pattern' => '96898',
             ],
             'US' => [
-                'format' => "%givenName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality, %administrativeArea %postalCode",
+                'format' => "%givenName %additionalName %familyName\n%organization\n%addressLine1\n%addressLine2\n%locality, %administrativeArea %postalCode",
                 'required_fields' => [
                     'addressLine1', 'locality', 'administrativeArea', 'postalCode',
                 ],


### PR DESCRIPTION
Middle name does not display even when it's specifically chosen as an optional field in Drupal.

https://www.drupal.org/project/address/issues/3282784