### PR TITLE
Use iso code for subdivision key

### DIFF
--- a/resources/subdivision/HK-1704dda0a4ad697dd5363d18c308abbc.json
+++ b/resources/subdivision/HK-1704dda0a4ad697dd5363d18c308abbc.json
@@ -4,202 +4,201 @@
 		"HK",
 		"New Territories"
 	],
-	"locale": "zh-Hant",
 	"subdivisions": {
 		"Kau To Shan": {
-			"local_code": "九肚山"
+			"name": "九肚山"
 		},
 		"Sheung Shui": {
-			"local_code": "上水"
+			"name": "上水"
 		},
 		"Tai Po": {
-			"local_code": "大埔"
+			"name": "大埔"
 		},
 		"Ting Kok Tai Po": {
-			"local_code": "大埔汀角"
+			"name": "大埔汀角"
 		},
 		"Lam Tsuen Tai Po": {
-			"local_code": "大埔林村"
+			"name": "大埔林村"
 		},
 		"Shuen Wan Tai Po": {
-			"local_code": "大埔船灣"
+			"name": "大埔船灣"
 		},
 		"Tai Po Kau": {
-			"local_code": "大埔滘"
+			"name": "大埔滘"
 		},
 		"Lantau Island": {
-			"local_code": "大嶼山"
+			"name": "大嶼山"
 		},
 		"Tai O Lantau Island": {
-			"local_code": "大嶼山大澳"
+			"name": "大嶼山大澳"
 		},
 		"Shek Pik Lantau Island": {
-			"local_code": "大嶼山石壁"
+			"name": "大嶼山石壁"
 		},
 		"Chek Lap Kok Lantau Island": {
-			"local_code": "大嶼山赤鱲角"
+			"name": "大嶼山赤鱲角"
 		},
 		"Ngong Ping Lantau Island": {
-			"local_code": "大嶼山昂坪"
+			"name": "大嶼山昂坪"
 		},
 		"Tung Chung Lantau Island": {
-			"local_code": "大嶼山東涌"
+			"name": "大嶼山東涌"
 		},
 		"Chi Ma Wan Lantau Island": {
-			"local_code": "大嶼山芝麻灣"
+			"name": "大嶼山芝麻灣"
 		},
 		"Cheung Sha Lantau Island": {
-			"local_code": "大嶼山長沙"
+			"name": "大嶼山長沙"
 		},
 		"Mui Wo Lantau Island": {
-			"local_code": "大嶼山梅窩"
+			"name": "大嶼山梅窩"
 		},
 		"Discovery Bay Lantau Island": {
-			"local_code": "大嶼山愉景灣"
+			"name": "大嶼山愉景灣"
 		},
 		"Tong Fuk Lantau Island": {
-			"local_code": "大嶼山塘福"
+			"name": "大嶼山塘福"
 		},
 		"Tai Lam": {
-			"local_code": "大欖"
+			"name": "大欖"
 		},
 		"Yuen Long": {
-			"local_code": "元朗"
+			"name": "元朗"
 		},
 		"Pat Heung Yuen Long": {
-			"local_code": "元朗八鄉"
+			"name": "元朗八鄉"
 		},
 		"Tai Tong Yuen Long": {
-			"local_code": "元朗大棠"
+			"name": "元朗大棠"
 		},
 		"Shek Kong Yuen Long": {
-			"local_code": "元朗石崗"
+			"name": "元朗石崗"
 		},
 		"Ping Shan Yuen Long": {
-			"local_code": "元朗屏山"
+			"name": "元朗屏山"
 		},
 		"Ha Tsuen Yuen Long": {
-			"local_code": "元朗廈村"
+			"name": "元朗廈村"
 		},
 		"San Tin Yuen Long": {
-			"local_code": "元朗新田"
+			"name": "元朗新田"
 		},
 		"Tam Mei Yuen Long": {
-			"local_code": "元朗潭尾"
+			"name": "元朗潭尾"
 		},
 		"Kam Tin Yuen Long": {
-			"local_code": "元朗錦田"
+			"name": "元朗錦田"
 		},
 		"Tin Shui Wai": {
-			"local_code": "天水圍"
+			"name": "天水圍"
 		},
 		"Tai Wo": {
-			"local_code": "太和"
+			"name": "太和"
 		},
 		"Tuen Mun": {
-			"local_code": "屯門"
-		},
-		"Fu Tei Tuen Mun": {
-			"local_code": "屯門虎地"
-		},
-		"San Hui Tuen Mun": {
-			"local_code": "屯門新墟"
-		},
-		"Lam Tei Tuen Mun": {
-			"local_code": "屯門藍地"
+			"name": "屯門"
 		},
 		"Siu Lam Tuen Mun": {
-			"local_code": "屯門小欖"
+			"name": "屯門小欖"
+		},
+		"Fu Tei Tuen Mun": {
+			"name": "屯門虎地"
+		},
+		"San Hui Tuen Mun": {
+			"name": "屯門新墟"
+		},
+		"Lam Tei Tuen Mun": {
+			"name": "屯門藍地"
 		},
 		"Kwu Tung": {
-			"local_code": "古洞"
+			"name": "古洞"
 		},
 		"Ta Kwu Ling": {
-			"local_code": "打鼓嶺"
+			"name": "打鼓嶺"
 		},
 		"Ting Kau": {
-			"local_code": "汀九"
+			"name": "汀九"
 		},
 		"Sai Kung": {
-			"local_code": "西貢"
+			"name": "西貢"
 		},
 		"Hang Hau Sai Kung": {
-			"local_code": "西貢坑口"
+			"name": "西貢坑口"
 		},
 		"Sha Tin": {
-			"local_code": "沙田"
+			"name": "沙田"
 		},
 		"Tai Wai Sha Tin": {
-			"local_code": "沙田大圍"
-		},
-		"Fo Tan Sha Tin": {
-			"local_code": "沙田火炭"
+			"name": "沙田大圍"
 		},
 		"Siu Lek Yuen Sha Tin": {
-			"local_code": "沙田小瀝源"
+			"name": "沙田小瀝源"
+		},
+		"Fo Tan Sha Tin": {
+			"name": "沙田火炭"
 		},
 		"Sha Tau Kok": {
-			"local_code": "沙頭角"
+			"name": "沙頭角"
 		},
 		"Peng Chau": {
-			"local_code": "坪洲"
+			"name": "坪洲"
 		},
 		"Ping Che": {
-			"local_code": "坪輋"
+			"name": "坪輋"
 		},
 		"Cheung Chau": {
-			"local_code": "長洲"
+			"name": "長洲"
 		},
 		"Tsing Yi": {
-			"local_code": "青衣"
+			"name": "青衣"
 		},
 		"Lamma Island": {
-			"local_code": "南丫島"
+			"name": "南丫島"
 		},
 		"Hung Shui Kiu": {
-			"local_code": "洪水橋"
+			"name": "洪水橋"
 		},
 		"Lau Fau Shan": {
-			"local_code": "流浮山"
+			"name": "流浮山"
 		},
 		"Fanling": {
-			"local_code": "粉嶺"
+			"name": "粉嶺"
 		},
 		"Kwan Tei Fanling": {
-			"local_code": "粉嶺軍地"
+			"name": "粉嶺軍地"
 		},
 		"Tsuen Wan": {
-			"local_code": "荃灣"
+			"name": "荃灣"
 		},
 		"Lo Wai Tsuen Wan": {
-			"local_code": "荃灣老圍"
+			"name": "荃灣老圍"
 		},
 		"Ma Liu Shui": {
-			"local_code": "馬料水"
+			"name": "馬料水"
 		},
 		"Ma On Shan": {
-			"local_code": "馬鞍山"
+			"name": "馬鞍山"
 		},
 		"Ma Wan": {
-			"local_code": "馬灣"
+			"name": "馬灣"
 		},
 		"Tseung Kwan O": {
-			"local_code": "將軍澳"
+			"name": "將軍澳"
 		},
 		"So Kwun Wat": {
-			"local_code": "掃管笏"
+			"name": "掃管笏"
 		},
 		"Sham Tseng": {
-			"local_code": "深井"
+			"name": "深井"
 		},
 		"Clear Water Bay": {
-			"local_code": "清水灣"
+			"name": "清水灣"
 		},
 		"Hei Ling Chau": {
-			"local_code": "喜靈洲"
+			"name": "喜靈洲"
 		},
 		"Kwai Chung": {
-			"local_code": "葵涌"
+			"name": "葵涌"
 		}
 	}
 }

--- a/resources/subdivision/HK-3092aff820e5475089a6b00c56720181.json
+++ b/resources/subdivision/HK-3092aff820e5475089a6b00c56720181.json
@@ -4,103 +4,102 @@
 		"HK",
 		"Kowloon"
 	],
-	"locale": "zh-Hant",
 	"subdivisions": {
 		"Kowloon City": {
-			"local_code": "九龍城"
+			"name": "九龍城"
 		},
 		"Kowloon Tong": {
-			"local_code": "九龍塘"
+			"name": "九龍塘"
 		},
 		"Kowloon Bay": {
-			"local_code": "九龍灣"
-		},
-		"To Kwa Wan": {
-			"local_code": "土瓜灣"
-		},
-		"Tai Kok Tsui": {
-			"local_code": "大角咀"
-		},
-		"Shek Kip Mei": {
-			"local_code": "石硤尾"
-		},
-		"Tsim Sha Tsui": {
-			"local_code": "尖沙咀"
-		},
-		"Jordan": {
-			"local_code": "佐敦"
-		},
-		"Ho Man Tin": {
-			"local_code": "何文田"
-		},
-		"Sau Mau Ping": {
-			"local_code": "秀茂坪"
-		},
-		"Mong Kok": {
-			"local_code": "旺角"
-		},
-		"Yau Ma Tei": {
-			"local_code": "油麻地"
-		},
-		"Yau Tong": {
-			"local_code": "油塘"
-		},
-		"Cheung Sha Wan": {
-			"local_code": "長沙灣"
-		},
-		"Hung Hom": {
-			"local_code": "紅磡"
-		},
-		"Mei Foo": {
-			"local_code": "美孚"
-		},
-		"Cha Kwo Ling": {
-			"local_code": "茶果嶺"
-		},
-		"Lai Chi Kok": {
-			"local_code": "荔枝角"
-		},
-		"Ma Tau Wai": {
-			"local_code": "馬頭圍"
-		},
-		"Choi Hung": {
-			"local_code": "彩虹"
-		},
-		"Sham Shui Po": {
-			"local_code": "深水埗"
-		},
-		"Wong Tai Sin": {
-			"local_code": "黃大仙"
-		},
-		"San Po Kong": {
-			"local_code": "新蒲崗"
-		},
-		"Tsz Wan Shan": {
-			"local_code": "慈雲山"
-		},
-		"Lok Fu": {
-			"local_code": "樂富"
-		},
-		"Wang Tau Hom": {
-			"local_code": "橫頭磡"
-		},
-		"Lam Tin": {
-			"local_code": "藍田"
-		},
-		"Kwun Tong": {
-			"local_code": "觀塘"
-		},
-		"Diamond Hill": {
-			"local_code": "鑽石山"
+			"name": "九龍灣"
 		},
 		"Yau Yat Chuen": {
-			"local_code": "又一村"
+			"name": "又一村"
+		},
+		"To Kwa Wan": {
+			"name": "土瓜灣"
+		},
+		"Tai Kok Tsui": {
+			"name": "大角咀"
 		},
 		"Ngau Chi Wan": {
-			"local_code": "牛池灣"
+			"name": "牛池灣"
 		},
 		"Ngau Tau Kok": {
-			"local_code": "牛頭角"
+			"name": "牛頭角"
+		},
+		"Shek Kip Mei": {
+			"name": "石硤尾"
+		},
+		"Tsim Sha Tsui": {
+			"name": "尖沙咀"
+		},
+		"Jordan": {
+			"name": "佐敦"
+		},
+		"Ho Man Tin": {
+			"name": "何文田"
+		},
+		"Sau Mau Ping": {
+			"name": "秀茂坪"
+		},
+		"Mong Kok": {
+			"name": "旺角"
+		},
+		"Yau Ma Tei": {
+			"name": "油麻地"
+		},
+		"Yau Tong": {
+			"name": "油塘"
+		},
+		"Cheung Sha Wan": {
+			"name": "長沙灣"
+		},
+		"Hung Hom": {
+			"name": "紅磡"
+		},
+		"Mei Foo": {
+			"name": "美孚"
+		},
+		"Cha Kwo Ling": {
+			"name": "茶果嶺"
+		},
+		"Lai Chi Kok": {
+			"name": "荔枝角"
+		},
+		"Ma Tau Wai": {
+			"name": "馬頭圍"
+		},
+		"Choi Hung": {
+			"name": "彩虹"
+		},
+		"Sham Shui Po": {
+			"name": "深水埗"
+		},
+		"Wong Tai Sin": {
+			"name": "黃大仙"
+		},
+		"San Po Kong": {
+			"name": "新蒲崗"
+		},
+		"Tsz Wan Shan": {
+			"name": "慈雲山"
+		},
+		"Lok Fu": {
+			"name": "樂富"
+		},
+		"Wang Tau Hom": {
+			"name": "橫頭磡"
+		},
+		"Lam Tin": {
+			"name": "藍田"
+		},
+		"Kwun Tong": {
+			"name": "觀塘"
+		},
+		"Diamond Hill": {
+			"name": "鑽石山"
 		}
 	}
 }

--- a/resources/subdivision/HK-b3c212c1eff0e5a1264c161b8e4e0d8f.json
+++ b/resources/subdivision/HK-b3c212c1eff0e5a1264c161b8e4e0d8f.json
@@ -4,88 +4,87 @@
 		"HK",
 		"Hong Kong Island"
 	],
-	"locale": "zh-Hant",
 	"subdivisions": {
 		"Sheung Wan": {
-			"local_code": "上環"
+			"name": "上環"
 		},
 		"Tai Hang": {
-			"local_code": "大坑"
+			"name": "大坑"
 		},
 		"Tai Tam": {
-			"local_code": "大潭"
+			"name": "大潭"
 		},
 		"The Peak": {
-			"local_code": "山頂"
+			"name": "山頂"
 		},
 		"Central": {
-			"local_code": "中環"
+			"name": "中環"
 		},
 		"North Point": {
-			"local_code": "北角"
+			"name": "北角"
 		},
 		"Mid-level": {
-			"local_code": "半山"
+			"name": "半山"
 		},
 		"Shek Tong Tsui": {
-			"local_code": "石塘咀"
+			"name": "石塘咀"
 		},
 		"Shek O": {
-			"local_code": "石澳"
+			"name": "石澳"
 		},
 		"Sai Ying Pun": {
-			"local_code": "西營盤"
+			"name": "西營盤"
 		},
 		"Sai Wan Ho": {
-			"local_code": "西灣河"
+			"name": "西灣河"
 		},
 		"Stanley": {
-			"local_code": "赤柱"
+			"name": "赤柱"
 		},
 		"Admiralty": {
-			"local_code": "金鐘"
+			"name": "金鐘"
 		},
 		"Aberdeen": {
-			"local_code": "香港仔"
+			"name": "香港仔"
 		},
 		"Chai Wan": {
-			"local_code": "柴灣"
+			"name": "柴灣"
 		},
 		"Kennedy Town": {
-			"local_code": "堅尼地城"
+			"name": "堅尼地城"
 		},
 		"Deep Water Bay": {
-			"local_code": "深水灣"
+			"name": "深水灣"
 		},
 		"Repulse Bay": {
-			"local_code": "淺水灣"
+			"name": "淺水灣"
 		},
 		"Chung Hom Kok": {
-			"local_code": "舂坎角"
+			"name": "舂坎角"
 		},
 		"Happy Valley": {
-			"local_code": "跑馬地"
+			"name": "跑馬地"
 		},
 		"Wong Chuk Hang": {
-			"local_code": "黃竹坑"
+			"name": "黃竹坑"
 		},
 		"Shau Kei Wan": {
-			"local_code": "筲箕灣"
+			"name": "筲箕灣"
 		},
 		"Causeway Bay": {
-			"local_code": "銅鑼灣"
+			"name": "銅鑼灣"
 		},
 		"Ap Lei Chau": {
-			"local_code": "鴨脷洲"
+			"name": "鴨脷洲"
 		},
 		"Pok Fu Lam": {
-			"local_code": "薄扶林"
+			"name": "薄扶林"
 		},
 		"Quarry Bay": {
-			"local_code": "鰂魚涌"
+			"name": "鰂魚涌"
 		},
 		"Wan Chai": {
-			"local_code": "灣仔"
+			"name": "灣仔"
 		}
 	}
 }

--- a/resources/subdivision/HK.json
+++ b/resources/subdivision/HK.json
@@ -1,17 +1,16 @@
 {
 	"country_code": "HK",
-	"locale": "zh-Hant",
 	"subdivisions": {
 		"Kowloon": {
-			"local_code": "九龍",
+			"name": "九龍",
 			"has_children": true
 		},
 		"Hong Kong Island": {
-			"local_code": "香港島",
+			"name": "香港島",
 			"has_children": true
 		},
 		"New Territories": {
-			"local_code": "新界",
+			"name": "新界",
 			"has_children": true
 		}
 	}


### PR DESCRIPTION
Building on PR #186...

In the interest of providing standardization to the data, this changes the key in the subdivision files from Google's arbitrary strings to the ISO ID for that subdivision, if found. Then, should there not be a "name" value in the subdivision, if the Google "key" and ISO ID are not the same it assigns the Google "key" as the name.