### PR TITLE
Use iso code for subdivision recompiled2

### DIFF
--- a/resources/subdivision/AD.json
+++ b/resources/subdivision/AD.json
@@ -1,32 +1,38 @@
 {
 	"country_code": "AD",
 	"subdivisions": {
-		"Parròquia d'Andorra la Vella": {
+		"07": {
 			"name": "Andorra la Vella",
 			"iso_code": "AD-07",
 			"postal_code_pattern": "AD50[01]"
 		},
-		"Canillo": {
+		"02": {
+			"name": "Canillo",
 			"iso_code": "AD-02",
 			"postal_code_pattern": "AD10[01]"
 		},
-		"Encamp": {
+		"03": {
+			"name": "Encamp",
 			"iso_code": "AD-03",
 			"postal_code_pattern": "AD20[01]"
 		},
-		"Escaldes-Engordany": {
+		"08": {
+			"name": "Escaldes-Engordany",
 			"iso_code": "AD-08",
 			"postal_code_pattern": "AD70[01]"
 		},
-		"La Massana": {
+		"04": {
+			"name": "La Massana",
 			"iso_code": "AD-04",
 			"postal_code_pattern": "AD40[01]"
 		},
-		"Ordino": {
+		"05": {
+			"name": "Ordino",
 			"iso_code": "AD-05",
 			"postal_code_pattern": "AD30[01]"
 		},
-		"Sant Julià de Lòria": {
+		"06": {
+			"name": "Sant Julià de Lòria",
 			"iso_code": "AD-06",
 			"postal_code_pattern": "AD60[01]"
 		}

--- a/resources/subdivision/AR.json
+++ b/resources/subdivision/AR.json
@@ -1,99 +1,123 @@
 {
 	"country_code": "AR",
 	"subdivisions": {
-		"Buenos Aires": {
+		"B": {
+			"name": "Buenos Aires",
 			"iso_code": "AR-B",
 			"postal_code_pattern": "B?[1-36-8]"
 		},
-		"Catamarca": {
+		"K": {
+			"name": "Catamarca",
 			"iso_code": "AR-K",
 			"postal_code_pattern": "K?[45]"
 		},
-		"Chaco": {
+		"H": {
+			"name": "Chaco",
 			"iso_code": "AR-H",
 			"postal_code_pattern": "H?3"
 		},
-		"Chubut": {
+		"U": {
+			"name": "Chubut",
 			"iso_code": "AR-U",
 			"postal_code_pattern": "U?[89]"
 		},
-		"Ciudad Autónoma de Buenos Aires": {
+		"C": {
+			"name": "Ciudad Autónoma de Buenos Aires",
 			"iso_code": "AR-C",
 			"postal_code_pattern": "C?1"
 		},
-		"Córdoba": {
+		"X": {
+			"name": "Córdoba",
 			"iso_code": "AR-X",
 			"postal_code_pattern": "X?[235-8]"
 		},
-		"Corrientes": {
+		"W": {
+			"name": "Corrientes",
 			"iso_code": "AR-W",
 			"postal_code_pattern": "W?3"
 		},
-		"Entre Ríos": {
+		"E": {
+			"name": "Entre Ríos",
 			"iso_code": "AR-E",
 			"postal_code_pattern": "E?[1-3]"
 		},
-		"Formosa": {
+		"P": {
+			"name": "Formosa",
 			"iso_code": "AR-P",
 			"postal_code_pattern": "P?[37]"
 		},
-		"Jujuy": {
+		"Y": {
+			"name": "Jujuy",
 			"iso_code": "AR-Y",
 			"postal_code_pattern": "Y?4"
 		},
-		"La Pampa": {
+		"L": {
+			"name": "La Pampa",
 			"iso_code": "AR-L",
 			"postal_code_pattern": "L?[3568]"
 		},
-		"La Rioja": {
+		"F": {
+			"name": "La Rioja",
 			"iso_code": "AR-F",
 			"postal_code_pattern": "F?5"
 		},
-		"Mendoza": {
+		"M": {
+			"name": "Mendoza",
 			"iso_code": "AR-M",
 			"postal_code_pattern": "M?[56]"
 		},
-		"Misiones": {
+		"N": {
+			"name": "Misiones",
 			"iso_code": "AR-N",
 			"postal_code_pattern": "N?3"
 		},
-		"Neuquén": {
+		"Q": {
+			"name": "Neuquén",
 			"iso_code": "AR-Q",
 			"postal_code_pattern": "Q?[38]"
 		},
-		"Río Negro": {
+		"R": {
+			"name": "Río Negro",
 			"iso_code": "AR-R",
 			"postal_code_pattern": "R?[89]"
 		},
-		"Salta": {
+		"A": {
+			"name": "Salta",
 			"iso_code": "AR-A",
 			"postal_code_pattern": "A?[34]"
 		},
-		"San Juan": {
+		"J": {
+			"name": "San Juan",
 			"iso_code": "AR-J",
 			"postal_code_pattern": "J?5"
 		},
-		"San Luis": {
+		"D": {
+			"name": "San Luis",
 			"iso_code": "AR-D",
 			"postal_code_pattern": "D?[4-6]"
 		},
-		"Santa Cruz": {
+		"Z": {
+			"name": "Santa Cruz",
 			"iso_code": "AR-Z",
 			"postal_code_pattern": "Z?[89]"
 		},
-		"Santa Fe": {
+		"S": {
+			"name": "Santa Fe",
 			"iso_code": "AR-S",
 			"postal_code_pattern": "S?[2368]"
 		},
-		"Santiago del Estero": {
+		"G": {
+			"name": "Santiago del Estero",
 			"iso_code": "AR-G",
 			"postal_code_pattern": "G?[2-5]"
 		},
-		"Tierra del Fuego": {
+		"V": {
+			"name": "Tierra del Fuego",
 			"iso_code": "AR-V",
 			"postal_code_pattern": "V?9"
 		},
-		"Tucumán": {
+		"T": {
+			"name": "Tucumán",
 			"iso_code": "AR-T",
 			"postal_code_pattern": "T?[45]"
 		}

--- a/resources/subdivision/BS.json
+++ b/resources/subdivision/BS.json
@@ -4,53 +4,65 @@
 		"Abaco": {
 			"name": "Abaco Islands"
 		},
-		"Acklins": {
+		"AK": {
+			"name": "Acklins",
 			"iso_code": "BS-AK"
 		},
 		"Andros": {
 			"name": "Andros Island"
 		},
-		"Berry Islands": {
+		"BY": {
+			"name": "Berry Islands",
 			"iso_code": "BS-BY"
 		},
-		"Bimini": {
+		"BI": {
+			"name": "Bimini",
 			"iso_code": "BS-BI"
 		},
-		"Cat Island": {
+		"CI": {
+			"name": "Cat Island",
 			"iso_code": "BS-CI"
 		},
 		"Crooked Island": [],
 		"Eleuthera": [],
-		"Exuma": {
+		"EX": {
 			"name": "Exuma and Cays",
 			"iso_code": "BS-EX"
 		},
 		"Grand Bahama": [],
-		"Harbour Island": {
+		"HI": {
+			"name": "Harbour Island",
 			"iso_code": "BS-HI"
 		},
-		"Inagua": {
+		"IN": {
+			"name": "Inagua",
 			"iso_code": "BS-IN"
 		},
-		"Long Island": {
+		"LI": {
+			"name": "Long Island",
 			"iso_code": "BS-LI"
 		},
-		"Mayaguana": {
+		"MG": {
+			"name": "Mayaguana",
 			"iso_code": "BS-MG"
 		},
 		"N.P.": {
 			"name": "New Providence"
 		},
-		"Ragged Island": {
+		"RI": {
+			"name": "Ragged Island",
 			"iso_code": "BS-RI"
 		},
-		"Rum Cay": {
+		"RC": {
+			"name": "Rum Cay",
 			"iso_code": "BS-RC"
 		},
-		"San Salvador": {
+		"SS": {
+			"name": "San Salvador",
 			"iso_code": "BS-SS"
 		},
-		"Spanish Wells": {
+		"SW": {
+			"name": "Spanish Wells",
 			"iso_code": "BS-SW"
 		}
 	}

--- a/resources/subdivision/CL-0ddfa7f557c248547750b3d03edcf44f.json
+++ b/resources/subdivision/CL-0ddfa7f557c248547750b3d03edcf44f.json
@@ -2,7 +2,7 @@
 	"country_code": "CL",
 	"parents": [
 		"CL",
-		"Tarapacá"
+		"TA"
 	],
 	"subdivisions": {
 		"Alto Hospicio": [],

--- a/resources/subdivision/CL-0ef8064dff83d77af13d3dd0700202f5.json
+++ b/resources/subdivision/CL-0ef8064dff83d77af13d3dd0700202f5.json
@@ -2,7 +2,7 @@
 	"country_code": "CL",
 	"parents": [
 		"CL",
-		"Región Metropolitana"
+		"RM"
 	],
 	"subdivisions": {
 		"Alhué": [],

--- a/resources/subdivision/CL-28ce0059f570c105e1b8c1d6074227f2.json
+++ b/resources/subdivision/CL-28ce0059f570c105e1b8c1d6074227f2.json
@@ -2,7 +2,7 @@
 	"country_code": "CL",
 	"parents": [
 		"CL",
-		"Biobío"
+		"BI"
 	],
 	"subdivisions": {
 		"Alto Biobío": [],

--- a/resources/subdivision/CL-363977597f3b3e82e745279610d86460.json
+++ b/resources/subdivision/CL-363977597f3b3e82e745279610d86460.json
@@ -2,7 +2,7 @@
 	"country_code": "CL",
 	"parents": [
 		"CL",
-		"Antofagasta"
+		"AN"
 	],
 	"subdivisions": {
 		"Antofagasta": [],

--- a/resources/subdivision/CL-3eff0bc68aa0397ffe7fcf8fe5636f6d.json
+++ b/resources/subdivision/CL-3eff0bc68aa0397ffe7fcf8fe5636f6d.json
@@ -2,7 +2,7 @@
 	"country_code": "CL",
 	"parents": [
 		"CL",
-		"Maule"
+		"ML"
 	],
 	"subdivisions": {
 		"Cauquenes": [],

--- a/resources/subdivision/CL-3fe5bce75c8e010e3af515c1e2962f35.json
+++ b/resources/subdivision/CL-3fe5bce75c8e010e3af515c1e2962f35.json
@@ -2,7 +2,7 @@
 	"country_code": "CL",
 	"parents": [
 		"CL",
-		"Coquimbo"
+		"CO"
 	],
 	"subdivisions": {
 		"Andacollo": [],

--- a/resources/subdivision/CL-6da87617d121197e1bb63780e7988c76.json
+++ b/resources/subdivision/CL-6da87617d121197e1bb63780e7988c76.json
@@ -2,7 +2,7 @@
 	"country_code": "CL",
 	"parents": [
 		"CL",
-		"Arica y Parinacota"
+		"AP"
 	],
 	"subdivisions": {
 		"Arica": [],

--- a/resources/subdivision/CL-77e8102b8d96d59cc89da560d41804fb.json
+++ b/resources/subdivision/CL-77e8102b8d96d59cc89da560d41804fb.json
@@ -2,7 +2,7 @@
 	"country_code": "CL",
 	"parents": [
 		"CL",
-		"Aysén"
+		"AI"
 	],
 	"subdivisions": {
 		"Aysén": [],

--- a/resources/subdivision/CL-78c55c23d5f2e616c4b092a40f5cea8d.json
+++ b/resources/subdivision/CL-78c55c23d5f2e616c4b092a40f5cea8d.json
@@ -2,7 +2,7 @@
 	"country_code": "CL",
 	"parents": [
 		"CL",
-		"Magallanes"
+		"MA"
 	],
 	"subdivisions": {
 		"Antártica": [],

--- a/resources/subdivision/CL-7f840d56b17cc32efd19481f0507beb3.json
+++ b/resources/subdivision/CL-7f840d56b17cc32efd19481f0507beb3.json
@@ -1,0 +1,17 @@
+{
+	"country_code": "CL",
+	"parents": [
+		"CL",
+		"NB"
+	],
+	"subdivisions": {
+		"Bulnes": [],
+		"Chillán": [],
+		"Coelemu": [],
+		"Coihueco": [],
+		"Quillón": [],
+		"Quirihue": [],
+		"San Carlos": [],
+		"Yungay": []
+	}
+}

--- a/resources/subdivision/CL-84834d16e1ada980f55f6d89684566d2.json
+++ b/resources/subdivision/CL-84834d16e1ada980f55f6d89684566d2.json
@@ -2,7 +2,7 @@
 	"country_code": "CL",
 	"parents": [
 		"CL",
-		"Atacama"
+		"AT"
 	],
 	"subdivisions": {
 		"Alto del Carmen": [],

--- a/resources/subdivision/CL-9a5e4f9f9d9753ef8b319a05a3fe0118.json
+++ b/resources/subdivision/CL-9a5e4f9f9d9753ef8b319a05a3fe0118.json
@@ -2,7 +2,7 @@
 	"country_code": "CL",
 	"parents": [
 		"CL",
-		"O'Higgins"
+		"LI"
 	],
 	"subdivisions": {
 		"Chépica": [],

--- a/resources/subdivision/CL-ca455bcf3671d5738cd0af141cfe74d4.json
+++ b/resources/subdivision/CL-ca455bcf3671d5738cd0af141cfe74d4.json
@@ -2,7 +2,7 @@
 	"country_code": "CL",
 	"parents": [
 		"CL",
-		"Valparaíso"
+		"VS"
 	],
 	"subdivisions": {
 		"Algarrobo": [],

--- a/resources/subdivision/CL-e74e3126faa4403d2cd0e6f661dd7e2a.json
+++ b/resources/subdivision/CL-e74e3126faa4403d2cd0e6f661dd7e2a.json
@@ -2,7 +2,7 @@
 	"country_code": "CL",
 	"parents": [
 		"CL",
-		"Los Lagos"
+		"LL"
 	],
 	"subdivisions": {
 		"Ancud": [],

--- a/resources/subdivision/CL-ec426f803459b488f0f3cb5253a01d98.json
+++ b/resources/subdivision/CL-ec426f803459b488f0f3cb5253a01d98.json
@@ -2,7 +2,7 @@
 	"country_code": "CL",
 	"parents": [
 		"CL",
-		"Los Ríos"
+		"LR"
 	],
 	"subdivisions": {
 		"Corral": [],

--- a/resources/subdivision/CL-f229fb6106aec24e1ff498ab53e9b49c.json
+++ b/resources/subdivision/CL-f229fb6106aec24e1ff498ab53e9b49c.json
@@ -2,7 +2,7 @@
 	"country_code": "CL",
 	"parents": [
 		"CL",
-		"Araucanía"
+		"AR"
 	],
 	"subdivisions": {
 		"Angol": [],

--- a/resources/subdivision/CL.json
+++ b/resources/subdivision/CL.json
@@ -1,70 +1,83 @@
 {
 	"country_code": "CL",
 	"subdivisions": {
-		"Antofagasta": {
+		"AN": {
+			"name": "Antofagasta",
 			"iso_code": "CL-AN",
 			"has_children": true
 		},
-		"Araucanía": {
+		"AR": {
+			"name": "Araucanía",
 			"iso_code": "CL-AR",
 			"has_children": true
 		},
-		"Arica y Parinacota": {
+		"AP": {
+			"name": "Arica y Parinacota",
 			"iso_code": "CL-AP",
 			"has_children": true
 		},
-		"Atacama": {
+		"AT": {
+			"name": "Atacama",
 			"iso_code": "CL-AT",
 			"has_children": true
 		},
-		"Aysén": {
+		"AI": {
 			"name": "Aysén del General Carlos Ibáñez del Campo",
 			"iso_code": "CL-AI",
 			"has_children": true
 		},
-		"Biobío": {
+		"BI": {
+			"name": "Biobío",
 			"iso_code": "CL-BI",
 			"has_children": true
 		},
-		"Coquimbo": {
+		"CO": {
+			"name": "Coquimbo",
 			"iso_code": "CL-CO",
 			"has_children": true
 		},
-		"O'Higgins": {
+		"LI": {
 			"name": "Libertador General Bernardo O'Higgins",
 			"iso_code": "CL-LI",
 			"has_children": true
 		},
-		"Los Lagos": {
+		"LL": {
+			"name": "Los Lagos",
 			"iso_code": "CL-LL",
 			"has_children": true
 		},
-		"Los Ríos": {
+		"LR": {
+			"name": "Los Ríos",
 			"iso_code": "CL-LR",
 			"has_children": true
 		},
-		"Magallanes": {
+		"MA": {
 			"name": "Magallanes y de la Antártica Chilena",
 			"iso_code": "CL-MA",
 			"has_children": true
 		},
-		"Maule": {
+		"ML": {
+			"name": "Maule",
 			"iso_code": "CL-ML",
 			"has_children": true
 		},
-		"Región Metropolitana": {
+		"RM": {
 			"name": "Metropolitana de Santiago",
 			"iso_code": "CL-RM",
 			"has_children": true
 		},
-		"Ñuble": {
-			"iso_code": "CL-NB"
+		"NB": {
+			"name": "Ñuble",
+			"iso_code": "CL-NB",
+			"has_children": true
 		},
-		"Tarapacá": {
+		"TA": {
+			"name": "Tarapacá",
 			"iso_code": "CL-TA",
 			"has_children": true
 		},
-		"Valparaíso": {
+		"VS": {
+			"name": "Valparaíso",
 			"iso_code": "CL-VS",
 			"has_children": true
 		}

--- a/resources/subdivision/CN--4a1b020d8de83d597edf56d49d986aed.json
+++ b/resources/subdivision/CN--4a1b020d8de83d597edf56d49d986aed.json
@@ -13,6 +13,9 @@
 		"Futian Qu": {
 			"local_code": "福田区"
 		},
+		"Guangming Qu": {
+			"local_code": "光明区"
+		},
 		"Longgang Qu": {
 			"local_code": "龙岗区"
 		},

--- a/resources/subdivision/CO.json
+++ b/resources/subdivision/CO.json
@@ -1,11 +1,6 @@
 {
 	"country_code": "CO",
 	"subdivisions": {
-		"DC": {
-			"name": "Distrito Capital de Bogotá",
-			"iso_code": "CO-DC",
-			"postal_code_pattern": "11\\d{4}"
-		},
 		"AMA": {
 			"name": "Amazonas",
 			"iso_code": "CO-AMA",
@@ -25,6 +20,11 @@
 			"name": "Atlántico",
 			"iso_code": "CO-ATL",
 			"postal_code_pattern": "08\\d{4}"
+		},
+		"DC": {
+			"name": "Distrito Capital de Bogotá",
+			"iso_code": "CO-DC",
+			"postal_code_pattern": "11\\d{4}"
 		},
 		"BOL": {
 			"name": "Bolívar",
@@ -61,6 +61,11 @@
 			"iso_code": "CO-CES",
 			"postal_code_pattern": "20\\d{4}"
 		},
+		"CHO": {
+			"name": "Chocó",
+			"iso_code": "CO-CHO",
+			"postal_code_pattern": "27\\d{4}"
+		},
 		"COR": {
 			"name": "Córdoba",
 			"iso_code": "CO-COR",
@@ -70,11 +75,6 @@
 			"name": "Cundinamarca",
 			"iso_code": "CO-CUN",
 			"postal_code_pattern": "25\\d{4}"
-		},
-		"CHO": {
-			"name": "Chocó",
-			"iso_code": "CO-CHO",
-			"postal_code_pattern": "27\\d{4}"
 		},
 		"GUA": {
 			"name": "Guanía",

--- a/resources/subdivision/CU.json
+++ b/resources/subdivision/CU.json
@@ -1,52 +1,68 @@
 {
 	"country_code": "CU",
 	"subdivisions": {
-		"Artemisa": {
+		"15": {
+			"name": "Artemisa",
 			"iso_code": "CU-15"
 		},
-		"Camagüey": {
+		"09": {
+			"name": "Camagüey",
 			"iso_code": "CU-09"
 		},
-		"Ciego de Ávila": {
+		"08": {
+			"name": "Ciego de Ávila",
 			"iso_code": "CU-08"
 		},
-		"Cienfuegos": {
+		"06": {
+			"name": "Cienfuegos",
 			"iso_code": "CU-06"
 		},
-		"Granma": {
+		"12": {
+			"name": "Granma",
 			"iso_code": "CU-12"
 		},
-		"Guantánamo": {
+		"14": {
+			"name": "Guantánamo",
 			"iso_code": "CU-14"
 		},
-		"Holguín": {
+		"11": {
+			"name": "Holguín",
 			"iso_code": "CU-11"
 		},
-		"Isla de la Juventud": {
+		"99": {
+			"name": "Isla de la Juventud",
 			"iso_code": "CU-99"
 		},
-		"La Habana": {
+		"03": {
+			"name": "La Habana",
 			"iso_code": "CU-03"
 		},
-		"Las Tunas": {
+		"10": {
+			"name": "Las Tunas",
 			"iso_code": "CU-10"
 		},
-		"Matanzas": {
+		"04": {
+			"name": "Matanzas",
 			"iso_code": "CU-04"
 		},
-		"Mayabeque": {
+		"16": {
+			"name": "Mayabeque",
 			"iso_code": "CU-16"
 		},
-		"Pinar del Río": {
+		"01": {
+			"name": "Pinar del Río",
 			"iso_code": "CU-01"
 		},
-		"Sancti Spíritus": {
+		"07": {
+			"name": "Sancti Spíritus",
 			"iso_code": "CU-07"
 		},
-		"Santiago de Cuba": {
+		"13": {
+			"name": "Santiago de Cuba",
 			"iso_code": "CU-13"
 		},
-		"Villa Clara": {
+		"05": {
+			"name": "Villa Clara",
 			"iso_code": "CU-05"
 		}
 	}

--- a/resources/subdivision/CV.json
+++ b/resources/subdivision/CV.json
@@ -1,23 +1,28 @@
 {
 	"country_code": "CV",
 	"subdivisions": {
-		"Boa Vista": {
+		"BV": {
+			"name": "Boa Vista",
 			"iso_code": "CV-BV"
 		},
-		"Brava": {
+		"BR": {
+			"name": "Brava",
 			"iso_code": "CV-BR"
 		},
 		"Fogo": [],
-		"Maio": {
+		"MA": {
+			"name": "Maio",
 			"iso_code": "CV-MA"
 		},
-		"Sal": {
+		"SL": {
+			"name": "Sal",
 			"iso_code": "CV-SL"
 		},
 		"Santiago": [],
 		"Santo Antão": [],
 		"São Nicolau": [],
-		"São Vicente": {
+		"SV": {
+			"name": "São Vicente",
 			"iso_code": "CV-SV"
 		}
 	}

--- a/resources/subdivision/HK-1704dda0a4ad697dd5363d18c308abbc.json
+++ b/resources/subdivision/HK-1704dda0a4ad697dd5363d18c308abbc.json
@@ -4,202 +4,201 @@
 		"HK",
 		"New Territories"
 	],
-	"locale": "zh-Hant",
 	"subdivisions": {
 		"Kau To Shan": {
-			"local_code": "九肚山"
+			"name": "九肚山"
 		},
 		"Sheung Shui": {
-			"local_code": "上水"
+			"name": "上水"
 		},
 		"Tai Po": {
-			"local_code": "大埔"
+			"name": "大埔"
 		},
 		"Ting Kok Tai Po": {
-			"local_code": "大埔汀角"
+			"name": "大埔汀角"
 		},
 		"Lam Tsuen Tai Po": {
-			"local_code": "大埔林村"
+			"name": "大埔林村"
 		},
 		"Shuen Wan Tai Po": {
-			"local_code": "大埔船灣"
+			"name": "大埔船灣"
 		},
 		"Tai Po Kau": {
-			"local_code": "大埔滘"
+			"name": "大埔滘"
 		},
 		"Lantau Island": {
-			"local_code": "大嶼山"
+			"name": "大嶼山"
 		},
 		"Tai O Lantau Island": {
-			"local_code": "大嶼山大澳"
+			"name": "大嶼山大澳"
 		},
 		"Shek Pik Lantau Island": {
-			"local_code": "大嶼山石壁"
+			"name": "大嶼山石壁"
 		},
 		"Chek Lap Kok Lantau Island": {
-			"local_code": "大嶼山赤鱲角"
+			"name": "大嶼山赤鱲角"
 		},
 		"Ngong Ping Lantau Island": {
-			"local_code": "大嶼山昂坪"
+			"name": "大嶼山昂坪"
 		},
 		"Tung Chung Lantau Island": {
-			"local_code": "大嶼山東涌"
+			"name": "大嶼山東涌"
 		},
 		"Chi Ma Wan Lantau Island": {
-			"local_code": "大嶼山芝麻灣"
+			"name": "大嶼山芝麻灣"
 		},
 		"Cheung Sha Lantau Island": {
-			"local_code": "大嶼山長沙"
+			"name": "大嶼山長沙"
 		},
 		"Mui Wo Lantau Island": {
-			"local_code": "大嶼山梅窩"
+			"name": "大嶼山梅窩"
 		},
 		"Discovery Bay Lantau Island": {
-			"local_code": "大嶼山愉景灣"
+			"name": "大嶼山愉景灣"
 		},
 		"Tong Fuk Lantau Island": {
-			"local_code": "大嶼山塘福"
+			"name": "大嶼山塘福"
 		},
 		"Tai Lam": {
-			"local_code": "大欖"
+			"name": "大欖"
 		},
 		"Yuen Long": {
-			"local_code": "元朗"
+			"name": "元朗"
 		},
 		"Pat Heung Yuen Long": {
-			"local_code": "元朗八鄉"
+			"name": "元朗八鄉"
 		},
 		"Tai Tong Yuen Long": {
-			"local_code": "元朗大棠"
+			"name": "元朗大棠"
 		},
 		"Shek Kong Yuen Long": {
-			"local_code": "元朗石崗"
+			"name": "元朗石崗"
 		},
 		"Ping Shan Yuen Long": {
-			"local_code": "元朗屏山"
+			"name": "元朗屏山"
 		},
 		"Ha Tsuen Yuen Long": {
-			"local_code": "元朗廈村"
+			"name": "元朗廈村"
 		},
 		"San Tin Yuen Long": {
-			"local_code": "元朗新田"
+			"name": "元朗新田"
 		},
 		"Tam Mei Yuen Long": {
-			"local_code": "元朗潭尾"
+			"name": "元朗潭尾"
 		},
 		"Kam Tin Yuen Long": {
-			"local_code": "元朗錦田"
+			"name": "元朗錦田"
 		},
 		"Tin Shui Wai": {
-			"local_code": "天水圍"
+			"name": "天水圍"
 		},
 		"Tai Wo": {
-			"local_code": "太和"
+			"name": "太和"
 		},
 		"Tuen Mun": {
-			"local_code": "屯門"
-		},
-		"Fu Tei Tuen Mun": {
-			"local_code": "屯門虎地"
-		},
-		"San Hui Tuen Mun": {
-			"local_code": "屯門新墟"
-		},
-		"Lam Tei Tuen Mun": {
-			"local_code": "屯門藍地"
+			"name": "屯門"
 		},
 		"Siu Lam Tuen Mun": {
-			"local_code": "屯門小欖"
+			"name": "屯門小欖"
+		},
+		"Fu Tei Tuen Mun": {
+			"name": "屯門虎地"
+		},
+		"San Hui Tuen Mun": {
+			"name": "屯門新墟"
+		},
+		"Lam Tei Tuen Mun": {
+			"name": "屯門藍地"
 		},
 		"Kwu Tung": {
-			"local_code": "古洞"
+			"name": "古洞"
 		},
 		"Ta Kwu Ling": {
-			"local_code": "打鼓嶺"
+			"name": "打鼓嶺"
 		},
 		"Ting Kau": {
-			"local_code": "汀九"
+			"name": "汀九"
 		},
 		"Sai Kung": {
-			"local_code": "西貢"
+			"name": "西貢"
 		},
 		"Hang Hau Sai Kung": {
-			"local_code": "西貢坑口"
+			"name": "西貢坑口"
 		},
 		"Sha Tin": {
-			"local_code": "沙田"
+			"name": "沙田"
 		},
 		"Tai Wai Sha Tin": {
-			"local_code": "沙田大圍"
-		},
-		"Fo Tan Sha Tin": {
-			"local_code": "沙田火炭"
+			"name": "沙田大圍"
 		},
 		"Siu Lek Yuen Sha Tin": {
-			"local_code": "沙田小瀝源"
+			"name": "沙田小瀝源"
+		},
+		"Fo Tan Sha Tin": {
+			"name": "沙田火炭"
 		},
 		"Sha Tau Kok": {
-			"local_code": "沙頭角"
+			"name": "沙頭角"
 		},
 		"Peng Chau": {
-			"local_code": "坪洲"
+			"name": "坪洲"
 		},
 		"Ping Che": {
-			"local_code": "坪輋"
+			"name": "坪輋"
 		},
 		"Cheung Chau": {
-			"local_code": "長洲"
+			"name": "長洲"
 		},
 		"Tsing Yi": {
-			"local_code": "青衣"
+			"name": "青衣"
 		},
 		"Lamma Island": {
-			"local_code": "南丫島"
+			"name": "南丫島"
 		},
 		"Hung Shui Kiu": {
-			"local_code": "洪水橋"
+			"name": "洪水橋"
 		},
 		"Lau Fau Shan": {
-			"local_code": "流浮山"
+			"name": "流浮山"
 		},
 		"Fanling": {
-			"local_code": "粉嶺"
+			"name": "粉嶺"
 		},
 		"Kwan Tei Fanling": {
-			"local_code": "粉嶺軍地"
+			"name": "粉嶺軍地"
 		},
 		"Tsuen Wan": {
-			"local_code": "荃灣"
+			"name": "荃灣"
 		},
 		"Lo Wai Tsuen Wan": {
-			"local_code": "荃灣老圍"
+			"name": "荃灣老圍"
 		},
 		"Ma Liu Shui": {
-			"local_code": "馬料水"
+			"name": "馬料水"
 		},
 		"Ma On Shan": {
-			"local_code": "馬鞍山"
+			"name": "馬鞍山"
 		},
 		"Ma Wan": {
-			"local_code": "馬灣"
+			"name": "馬灣"
 		},
 		"Tseung Kwan O": {
-			"local_code": "將軍澳"
+			"name": "將軍澳"
 		},
 		"So Kwun Wat": {
-			"local_code": "掃管笏"
+			"name": "掃管笏"
 		},
 		"Sham Tseng": {
-			"local_code": "深井"
+			"name": "深井"
 		},
 		"Clear Water Bay": {
-			"local_code": "清水灣"
+			"name": "清水灣"
 		},
 		"Hei Ling Chau": {
-			"local_code": "喜靈洲"
+			"name": "喜靈洲"
 		},
 		"Kwai Chung": {
-			"local_code": "葵涌"
+			"name": "葵涌"
 		}
 	}
 }

--- a/resources/subdivision/HK-3092aff820e5475089a6b00c56720181.json
+++ b/resources/subdivision/HK-3092aff820e5475089a6b00c56720181.json
@@ -4,103 +4,102 @@
 		"HK",
 		"Kowloon"
 	],
-	"locale": "zh-Hant",
 	"subdivisions": {
 		"Kowloon City": {
-			"local_code": "九龍城"
+			"name": "九龍城"
 		},
 		"Kowloon Tong": {
-			"local_code": "九龍塘"
+			"name": "九龍塘"
 		},
 		"Kowloon Bay": {
-			"local_code": "九龍灣"
-		},
-		"To Kwa Wan": {
-			"local_code": "土瓜灣"
-		},
-		"Tai Kok Tsui": {
-			"local_code": "大角咀"
-		},
-		"Shek Kip Mei": {
-			"local_code": "石硤尾"
-		},
-		"Tsim Sha Tsui": {
-			"local_code": "尖沙咀"
-		},
-		"Jordan": {
-			"local_code": "佐敦"
-		},
-		"Ho Man Tin": {
-			"local_code": "何文田"
-		},
-		"Sau Mau Ping": {
-			"local_code": "秀茂坪"
-		},
-		"Mong Kok": {
-			"local_code": "旺角"
-		},
-		"Yau Ma Tei": {
-			"local_code": "油麻地"
-		},
-		"Yau Tong": {
-			"local_code": "油塘"
-		},
-		"Cheung Sha Wan": {
-			"local_code": "長沙灣"
-		},
-		"Hung Hom": {
-			"local_code": "紅磡"
-		},
-		"Mei Foo": {
-			"local_code": "美孚"
-		},
-		"Cha Kwo Ling": {
-			"local_code": "茶果嶺"
-		},
-		"Lai Chi Kok": {
-			"local_code": "荔枝角"
-		},
-		"Ma Tau Wai": {
-			"local_code": "馬頭圍"
-		},
-		"Choi Hung": {
-			"local_code": "彩虹"
-		},
-		"Sham Shui Po": {
-			"local_code": "深水埗"
-		},
-		"Wong Tai Sin": {
-			"local_code": "黃大仙"
-		},
-		"San Po Kong": {
-			"local_code": "新蒲崗"
-		},
-		"Tsz Wan Shan": {
-			"local_code": "慈雲山"
-		},
-		"Lok Fu": {
-			"local_code": "樂富"
-		},
-		"Wang Tau Hom": {
-			"local_code": "橫頭磡"
-		},
-		"Lam Tin": {
-			"local_code": "藍田"
-		},
-		"Kwun Tong": {
-			"local_code": "觀塘"
-		},
-		"Diamond Hill": {
-			"local_code": "鑽石山"
+			"name": "九龍灣"
 		},
 		"Yau Yat Chuen": {
-			"local_code": "又一村"
+			"name": "又一村"
+		},
+		"To Kwa Wan": {
+			"name": "土瓜灣"
+		},
+		"Tai Kok Tsui": {
+			"name": "大角咀"
 		},
 		"Ngau Chi Wan": {
-			"local_code": "牛池灣"
+			"name": "牛池灣"
 		},
 		"Ngau Tau Kok": {
-			"local_code": "牛頭角"
+			"name": "牛頭角"
+		},
+		"Shek Kip Mei": {
+			"name": "石硤尾"
+		},
+		"Tsim Sha Tsui": {
+			"name": "尖沙咀"
+		},
+		"Jordan": {
+			"name": "佐敦"
+		},
+		"Ho Man Tin": {
+			"name": "何文田"
+		},
+		"Sau Mau Ping": {
+			"name": "秀茂坪"
+		},
+		"Mong Kok": {
+			"name": "旺角"
+		},
+		"Yau Ma Tei": {
+			"name": "油麻地"
+		},
+		"Yau Tong": {
+			"name": "油塘"
+		},
+		"Cheung Sha Wan": {
+			"name": "長沙灣"
+		},
+		"Hung Hom": {
+			"name": "紅磡"
+		},
+		"Mei Foo": {
+			"name": "美孚"
+		},
+		"Cha Kwo Ling": {
+			"name": "茶果嶺"
+		},
+		"Lai Chi Kok": {
+			"name": "荔枝角"
+		},
+		"Ma Tau Wai": {
+			"name": "馬頭圍"
+		},
+		"Choi Hung": {
+			"name": "彩虹"
+		},
+		"Sham Shui Po": {
+			"name": "深水埗"
+		},
+		"Wong Tai Sin": {
+			"name": "黃大仙"
+		},
+		"San Po Kong": {
+			"name": "新蒲崗"
+		},
+		"Tsz Wan Shan": {
+			"name": "慈雲山"
+		},
+		"Lok Fu": {
+			"name": "樂富"
+		},
+		"Wang Tau Hom": {
+			"name": "橫頭磡"
+		},
+		"Lam Tin": {
+			"name": "藍田"
+		},
+		"Kwun Tong": {
+			"name": "觀塘"
+		},
+		"Diamond Hill": {
+			"name": "鑽石山"
 		}
 	}
 }

--- a/resources/subdivision/HK-b3c212c1eff0e5a1264c161b8e4e0d8f.json
+++ b/resources/subdivision/HK-b3c212c1eff0e5a1264c161b8e4e0d8f.json
@@ -4,88 +4,87 @@
 		"HK",
 		"Hong Kong Island"
 	],
-	"locale": "zh-Hant",
 	"subdivisions": {
 		"Sheung Wan": {
-			"local_code": "上環"
+			"name": "上環"
 		},
 		"Tai Hang": {
-			"local_code": "大坑"
+			"name": "大坑"
 		},
 		"Tai Tam": {
-			"local_code": "大潭"
+			"name": "大潭"
 		},
 		"The Peak": {
-			"local_code": "山頂"
+			"name": "山頂"
 		},
 		"Central": {
-			"local_code": "中環"
+			"name": "中環"
 		},
 		"North Point": {
-			"local_code": "北角"
+			"name": "北角"
 		},
 		"Mid-level": {
-			"local_code": "半山"
+			"name": "半山"
 		},
 		"Shek Tong Tsui": {
-			"local_code": "石塘咀"
+			"name": "石塘咀"
 		},
 		"Shek O": {
-			"local_code": "石澳"
+			"name": "石澳"
 		},
 		"Sai Ying Pun": {
-			"local_code": "西營盤"
+			"name": "西營盤"
 		},
 		"Sai Wan Ho": {
-			"local_code": "西灣河"
+			"name": "西灣河"
 		},
 		"Stanley": {
-			"local_code": "赤柱"
+			"name": "赤柱"
 		},
 		"Admiralty": {
-			"local_code": "金鐘"
+			"name": "金鐘"
 		},
 		"Aberdeen": {
-			"local_code": "香港仔"
+			"name": "香港仔"
 		},
 		"Chai Wan": {
-			"local_code": "柴灣"
+			"name": "柴灣"
 		},
 		"Kennedy Town": {
-			"local_code": "堅尼地城"
+			"name": "堅尼地城"
 		},
 		"Deep Water Bay": {
-			"local_code": "深水灣"
+			"name": "深水灣"
 		},
 		"Repulse Bay": {
-			"local_code": "淺水灣"
+			"name": "淺水灣"
 		},
 		"Chung Hom Kok": {
-			"local_code": "舂坎角"
+			"name": "舂坎角"
 		},
 		"Happy Valley": {
-			"local_code": "跑馬地"
+			"name": "跑馬地"
 		},
 		"Wong Chuk Hang": {
-			"local_code": "黃竹坑"
+			"name": "黃竹坑"
 		},
 		"Shau Kei Wan": {
-			"local_code": "筲箕灣"
+			"name": "筲箕灣"
 		},
 		"Causeway Bay": {
-			"local_code": "銅鑼灣"
+			"name": "銅鑼灣"
 		},
 		"Ap Lei Chau": {
-			"local_code": "鴨脷洲"
+			"name": "鴨脷洲"
 		},
 		"Pok Fu Lam": {
-			"local_code": "薄扶林"
+			"name": "薄扶林"
 		},
 		"Quarry Bay": {
-			"local_code": "鰂魚涌"
+			"name": "鰂魚涌"
 		},
 		"Wan Chai": {
-			"local_code": "灣仔"
+			"name": "灣仔"
 		}
 	}
 }

--- a/resources/subdivision/HK.json
+++ b/resources/subdivision/HK.json
@@ -1,17 +1,16 @@
 {
 	"country_code": "HK",
-	"locale": "zh-Hant",
 	"subdivisions": {
 		"Kowloon": {
-			"local_code": "九龍",
+			"name": "九龍",
 			"has_children": true
 		},
 		"Hong Kong Island": {
-			"local_code": "香港島",
+			"name": "香港島",
 			"has_children": true
 		},
 		"New Territories": {
-			"local_code": "新界",
+			"name": "新界",
 			"has_children": true
 		}
 	}

--- a/resources/subdivision/IE.json
+++ b/resources/subdivision/IE.json
@@ -1,82 +1,108 @@
 {
 	"country_code": "IE",
 	"subdivisions": {
-		"Co. Carlow": {
+		"CW": {
+			"name": "Co. Carlow",
 			"iso_code": "IE-CW"
 		},
-		"Co. Cavan": {
+		"CN": {
+			"name": "Co. Cavan",
 			"iso_code": "IE-CN"
 		},
-		"Co. Clare": {
+		"CE": {
+			"name": "Co. Clare",
 			"iso_code": "IE-CE"
 		},
-		"Co. Cork": {
+		"CO": {
+			"name": "Co. Cork",
 			"iso_code": "IE-CO"
 		},
-		"Co. Donegal": {
+		"DL": {
+			"name": "Co. Donegal",
 			"iso_code": "IE-DL"
 		},
-		"Co. Dublin": {
+		"D": {
+			"name": "Co. Dublin",
 			"iso_code": "IE-D"
 		},
-		"Co. Galway": {
+		"G": {
+			"name": "Co. Galway",
 			"iso_code": "IE-G"
 		},
-		"Co. Kerry": {
+		"KY": {
+			"name": "Co. Kerry",
 			"iso_code": "IE-KY"
 		},
-		"Co. Kildare": {
+		"KE": {
+			"name": "Co. Kildare",
 			"iso_code": "IE-KE"
 		},
-		"Co. Kilkenny": {
+		"KK": {
+			"name": "Co. Kilkenny",
 			"iso_code": "IE-KK"
 		},
-		"Co. Laois": {
+		"LS": {
+			"name": "Co. Laois",
 			"iso_code": "IE-LS"
 		},
-		"Co. Leitrim": {
+		"LM": {
+			"name": "Co. Leitrim",
 			"iso_code": "IE-LM"
 		},
-		"Co. Limerick": {
+		"LK": {
+			"name": "Co. Limerick",
 			"iso_code": "IE-LK"
 		},
-		"Co. Longford": {
+		"LD": {
+			"name": "Co. Longford",
 			"iso_code": "IE-LD"
 		},
-		"Co. Louth": {
+		"LH": {
+			"name": "Co. Louth",
 			"iso_code": "IE-LH"
 		},
-		"Co. Mayo": {
+		"MO": {
+			"name": "Co. Mayo",
 			"iso_code": "IE-MO"
 		},
-		"Co. Meath": {
+		"MH": {
+			"name": "Co. Meath",
 			"iso_code": "IE-MH"
 		},
-		"Co. Monaghan": {
+		"MN": {
+			"name": "Co. Monaghan",
 			"iso_code": "IE-MN"
 		},
-		"Co. Offaly": {
+		"OY": {
+			"name": "Co. Offaly",
 			"iso_code": "IE-OY"
 		},
-		"Co. Roscommon": {
+		"RN": {
+			"name": "Co. Roscommon",
 			"iso_code": "IE-RN"
 		},
-		"Co. Sligo": {
+		"SO": {
+			"name": "Co. Sligo",
 			"iso_code": "IE-SO"
 		},
-		"Co. Tipperary": {
+		"TA": {
+			"name": "Co. Tipperary",
 			"iso_code": "IE-TA"
 		},
-		"Co. Waterford": {
+		"WD": {
+			"name": "Co. Waterford",
 			"iso_code": "IE-WD"
 		},
-		"Co. Westmeath": {
+		"WH": {
+			"name": "Co. Westmeath",
 			"iso_code": "IE-WH"
 		},
-		"Co. Wexford": {
+		"WX": {
+			"name": "Co. Wexford",
 			"iso_code": "IE-WX"
 		},
-		"Co. Wicklow": {
+		"WW": {
+			"name": "Co. Wicklow",
 			"iso_code": "IE-WW"
 		}
 	}

--- a/resources/subdivision/IN.json
+++ b/resources/subdivision/IN.json
@@ -1,150 +1,183 @@
 {
 	"country_code": "IN",
 	"subdivisions": {
-		"Andaman and Nicobar Islands": {
+		"AN": {
 			"name": "Andaman & Nicobar",
 			"iso_code": "IN-AN",
 			"postal_code_pattern": "744"
 		},
-		"Andhra Pradesh": {
+		"AP": {
+			"name": "Andhra Pradesh",
 			"iso_code": "IN-AP",
 			"postal_code_pattern": "5[0-3]"
 		},
-		"Arunachal Pradesh": {
+		"AR": {
+			"name": "Arunachal Pradesh",
 			"iso_code": "IN-AR",
 			"postal_code_pattern": "79[0-2]"
 		},
-		"Assam": {
+		"AS": {
+			"name": "Assam",
 			"iso_code": "IN-AS",
 			"postal_code_pattern": "78"
 		},
-		"Bihar": {
+		"BR": {
+			"name": "Bihar",
 			"iso_code": "IN-BR",
 			"postal_code_pattern": "8[0-5]"
 		},
-		"Chandigarh": {
+		"CH": {
+			"name": "Chandigarh",
 			"iso_code": "IN-CH",
 			"postal_code_pattern": "16|1440[3-9]"
 		},
-		"Chhattisgarh": {
+		"CT": {
+			"name": "Chhattisgarh",
 			"iso_code": "IN-CT",
 			"postal_code_pattern": "49"
 		},
-		"Dadra and Nagar Haveli and Daman and Diu": {
+		"DH": {
 			"name": "Dadra & Nagar Haveli & Daman & Diu",
 			"iso_code": "IN-DH",
 			"postal_code_pattern": "396|362"
 		},
-		"Delhi": {
+		"DL": {
+			"name": "Delhi",
 			"iso_code": "IN-DL",
 			"postal_code_pattern": "11"
 		},
-		"Goa": {
+		"GA": {
+			"name": "Goa",
 			"iso_code": "IN-GA",
 			"postal_code_pattern": "403"
 		},
-		"Gujarat": {
+		"GJ": {
+			"name": "Gujarat",
 			"iso_code": "IN-GJ",
 			"postal_code_pattern": "3[6-9]"
 		},
-		"Haryana": {
+		"HR": {
+			"name": "Haryana",
 			"iso_code": "IN-HR",
 			"postal_code_pattern": "1[23]"
 		},
-		"Himachal Pradesh": {
+		"HP": {
+			"name": "Himachal Pradesh",
 			"iso_code": "IN-HP",
 			"postal_code_pattern": "17"
 		},
-		"Jammu and Kashmir": {
+		"JK": {
 			"name": "Jammu & Kashmir",
 			"iso_code": "IN-JK",
 			"postal_code_pattern": "1[89]"
 		},
-		"Jharkhand": {
+		"JH": {
+			"name": "Jharkhand",
 			"iso_code": "IN-JH",
 			"postal_code_pattern": "81[4-9]|82|83[0-5]"
 		},
-		"Karnataka": {
+		"KA": {
+			"name": "Karnataka",
 			"iso_code": "IN-KA",
 			"postal_code_pattern": "5[4-9]|53[7-9]"
 		},
-		"Kerala": {
+		"KL": {
+			"name": "Kerala",
 			"iso_code": "IN-KL",
 			"postal_code_pattern": "6[7-9]|6010|607008|777"
 		},
-		"Ladakh": {
+		"LA": {
+			"name": "Ladakh",
 			"iso_code": "IN-LA",
 			"postal_code_pattern": "194"
 		},
-		"Lakshadweep": {
+		"LD": {
+			"name": "Lakshadweep",
 			"iso_code": "IN-LD",
 			"postal_code_pattern": "682"
 		},
-		"Madhya Pradesh": {
+		"MP": {
+			"name": "Madhya Pradesh",
 			"iso_code": "IN-MP",
 			"postal_code_pattern": "4[5-8]|490"
 		},
-		"Maharashtra": {
+		"MH": {
+			"name": "Maharashtra",
 			"iso_code": "IN-MH",
 			"postal_code_pattern": "4[0-4]"
 		},
-		"Manipur": {
+		"MN": {
+			"name": "Manipur",
 			"iso_code": "IN-MN",
 			"postal_code_pattern": "79[56]"
 		},
-		"Meghalaya": {
+		"ML": {
+			"name": "Meghalaya",
 			"iso_code": "IN-ML",
 			"postal_code_pattern": "79[34]"
 		},
-		"Mizoram": {
+		"MZ": {
+			"name": "Mizoram",
 			"iso_code": "IN-MZ",
 			"postal_code_pattern": "796"
 		},
-		"Nagaland": {
+		"NL": {
+			"name": "Nagaland",
 			"iso_code": "IN-NL",
 			"postal_code_pattern": "79[78]"
 		},
-		"Odisha": {
+		"OR": {
+			"name": "Odisha",
 			"iso_code": "IN-OR",
 			"postal_code_pattern": "7[5-7]"
 		},
-		"Puducherry": {
+		"PY": {
+			"name": "Puducherry",
 			"iso_code": "IN-PY",
 			"postal_code_pattern": "60[579]"
 		},
-		"Punjab": {
+		"PB": {
+			"name": "Punjab",
 			"iso_code": "IN-PB",
 			"postal_code_pattern": "1[456]"
 		},
-		"Rajasthan": {
+		"RJ": {
+			"name": "Rajasthan",
 			"iso_code": "IN-RJ",
 			"postal_code_pattern": "3[0-4]"
 		},
-		"Sikkim": {
+		"SK": {
+			"name": "Sikkim",
 			"iso_code": "IN-SK",
 			"postal_code_pattern": "737|750"
 		},
-		"Tamil Nadu": {
+		"TN": {
+			"name": "Tamil Nadu",
 			"iso_code": "IN-TN",
 			"postal_code_pattern": "6[0-6]|536"
 		},
-		"Telangana": {
+		"TG": {
+			"name": "Telangana",
 			"iso_code": "IN-TG",
 			"postal_code_pattern": "5[0-3]"
 		},
-		"Tripura": {
+		"TR": {
+			"name": "Tripura",
 			"iso_code": "IN-TR",
 			"postal_code_pattern": "799"
 		},
-		"Uttar Pradesh": {
+		"UP": {
+			"name": "Uttar Pradesh",
 			"iso_code": "IN-UP",
 			"postal_code_pattern": "2[0-35-8]|24[0-7]|26[12]"
 		},
-		"Uttarakhand": {
+		"UT": {
+			"name": "Uttarakhand",
 			"iso_code": "IN-UT",
 			"postal_code_pattern": "24[46-9]|254|26[23]"
 		},
-		"West Bengal": {
+		"WB": {
+			"name": "West Bengal",
 			"iso_code": "IN-WB",
 			"postal_code_pattern": "7[0-4]"
 		}

--- a/resources/subdivision/JM.json
+++ b/resources/subdivision/JM.json
@@ -1,46 +1,60 @@
 {
 	"country_code": "JM",
 	"subdivisions": {
-		"Clarendon": {
+		"13": {
+			"name": "Clarendon",
 			"iso_code": "JM-13"
 		},
-		"Hanover": {
+		"09": {
+			"name": "Hanover",
 			"iso_code": "JM-09"
 		},
-		"Kingston": {
+		"01": {
+			"name": "Kingston",
 			"iso_code": "JM-01"
 		},
-		"Manchester": {
+		"12": {
+			"name": "Manchester",
 			"iso_code": "JM-12"
 		},
-		"Portland": {
+		"04": {
+			"name": "Portland",
 			"iso_code": "JM-04"
 		},
-		"St. Andrew": {
+		"02": {
+			"name": "St. Andrew",
 			"iso_code": "JM-02"
 		},
-		"St. Ann": {
+		"06": {
+			"name": "St. Ann",
 			"iso_code": "JM-06"
 		},
-		"St. Catherine": {
+		"14": {
+			"name": "St. Catherine",
 			"iso_code": "JM-14"
 		},
-		"St. Elizabeth": {
+		"11": {
+			"name": "St. Elizabeth",
 			"iso_code": "JM-11"
 		},
-		"St. James": {
+		"08": {
+			"name": "St. James",
 			"iso_code": "JM-08"
 		},
-		"St. Mary": {
+		"05": {
+			"name": "St. Mary",
 			"iso_code": "JM-05"
 		},
-		"St. Thomas": {
+		"03": {
+			"name": "St. Thomas",
 			"iso_code": "JM-03"
 		},
-		"Trelawny": {
+		"07": {
+			"name": "Trelawny",
 			"iso_code": "JM-07"
 		},
-		"Westmoreland": {
+		"10": {
+			"name": "Westmoreland",
 			"iso_code": "JM-10"
 		}
 	}

--- a/resources/subdivision/KN.json
+++ b/resources/subdivision/KN.json
@@ -1,10 +1,12 @@
 {
 	"country_code": "KN",
 	"subdivisions": {
-		"Nevis": {
+		"N": {
+			"name": "Nevis",
 			"iso_code": "KN-N"
 		},
-		"St. Kitts": {
+		"K": {
+			"name": "St. Kitts",
 			"iso_code": "KN-K"
 		}
 	}

--- a/resources/subdivision/KR-3eb61e5fe6595470532d82f2132f1f33.json
+++ b/resources/subdivision/KR-3eb61e5fe6595470532d82f2132f1f33.json
@@ -44,7 +44,7 @@
 		},
 		"Jung-gu": {
 			"local_code": "중구",
-			"postal_code_pattern": "223"
+			"postal_code_pattern": "22[34]"
 		}
 	}
 }

--- a/resources/subdivision/MX.json
+++ b/resources/subdivision/MX.json
@@ -1,162 +1,162 @@
 {
 	"country_code": "MX",
 	"subdivisions": {
-		"Ags.": {
+		"AGU": {
 			"name": "Aguascalientes",
 			"iso_code": "MX-AGU",
 			"postal_code_pattern": "20"
 		},
-		"B.C.": {
+		"BCN": {
 			"name": "Baja California",
 			"iso_code": "MX-BCN",
 			"postal_code_pattern": "2[12]"
 		},
-		"B.C.S.": {
+		"BCS": {
 			"name": "Baja California Sur",
 			"iso_code": "MX-BCS",
 			"postal_code_pattern": "23"
 		},
-		"Camp.": {
+		"CAM": {
 			"name": "Campeche",
 			"iso_code": "MX-CAM",
 			"postal_code_pattern": "24"
 		},
-		"Chis.": {
+		"CHP": {
 			"name": "Chiapas",
 			"iso_code": "MX-CHP",
 			"postal_code_pattern": "29|30"
 		},
-		"Chih.": {
+		"CHH": {
 			"name": "Chihuahua",
 			"iso_code": "MX-CHH",
 			"postal_code_pattern": "3[1-3]"
 		},
-		"CDMX": {
+		"CMX": {
 			"name": "Ciudad de México",
 			"iso_code": "MX-CMX",
 			"postal_code_pattern": "0|1[0-6]"
 		},
-		"Coah.": {
+		"COA": {
 			"name": "Coahuila de Zaragoza",
 			"iso_code": "MX-COA",
 			"postal_code_pattern": "2[5-7]"
 		},
-		"Col.": {
+		"COL": {
 			"name": "Colima",
 			"iso_code": "MX-COL",
 			"postal_code_pattern": "28"
 		},
-		"Dgo.": {
+		"DUR": {
 			"name": "Durango",
 			"iso_code": "MX-DUR",
 			"postal_code_pattern": "3[45]"
 		},
-		"Méx.": {
+		"MEX": {
 			"name": "Estado de México",
 			"iso_code": "MX-MEX",
 			"postal_code_pattern": "5[0-7]"
 		},
-		"Gto.": {
+		"GUA": {
 			"name": "Guanajuato",
 			"iso_code": "MX-GUA",
 			"postal_code_pattern": "3[6-8]"
 		},
-		"Gro.": {
+		"GRO": {
 			"name": "Guerrero",
 			"iso_code": "MX-GRO",
 			"postal_code_pattern": "39|4[01]"
 		},
-		"Hgo.": {
+		"HID": {
 			"name": "Hidalgo",
 			"iso_code": "MX-HID",
 			"postal_code_pattern": "4[23]"
 		},
-		"Jal.": {
+		"JAL": {
 			"name": "Jalisco",
 			"iso_code": "MX-JAL",
 			"postal_code_pattern": "4[4-9]"
 		},
-		"Mich.": {
+		"MIC": {
 			"name": "Michoacán",
 			"iso_code": "MX-MIC",
 			"postal_code_pattern": "5[89]|6[01]"
 		},
-		"Mor.": {
+		"MOR": {
 			"name": "Morelos",
 			"iso_code": "MX-MOR",
 			"postal_code_pattern": "62"
 		},
-		"Nay.": {
+		"NAY": {
 			"name": "Nayarit",
 			"iso_code": "MX-NAY",
 			"postal_code_pattern": "63"
 		},
-		"N.L.": {
+		"NLE": {
 			"name": "Nuevo León",
 			"iso_code": "MX-NLE",
 			"postal_code_pattern": "6[4-7]"
 		},
-		"Oax.": {
+		"OAX": {
 			"name": "Oaxaca",
 			"iso_code": "MX-OAX",
 			"postal_code_pattern": "6[89]|7[01]"
 		},
-		"Pue.": {
+		"PUE": {
 			"name": "Puebla",
 			"iso_code": "MX-PUE",
 			"postal_code_pattern": "7[2-5]"
 		},
-		"Qro.": {
+		"QUE": {
 			"name": "Querétaro",
 			"iso_code": "MX-QUE",
 			"postal_code_pattern": "76"
 		},
-		"Q.R.": {
+		"ROO": {
 			"name": "Quintana Roo",
 			"iso_code": "MX-ROO",
 			"postal_code_pattern": "77"
 		},
-		"S.L.P.": {
+		"SLP": {
 			"name": "San Luis Potosí",
 			"iso_code": "MX-SLP",
 			"postal_code_pattern": "7[89]"
 		},
-		"Sin.": {
+		"SIN": {
 			"name": "Sinaloa",
 			"iso_code": "MX-SIN",
 			"postal_code_pattern": "8[0-2]"
 		},
-		"Son.": {
+		"SON": {
 			"name": "Sonora",
 			"iso_code": "MX-SON",
 			"postal_code_pattern": "8[3-5]"
 		},
-		"Tab.": {
+		"TAB": {
 			"name": "Tabasco",
 			"iso_code": "MX-TAB",
 			"postal_code_pattern": "86"
 		},
-		"Tamps.": {
+		"TAM": {
 			"name": "Tamaulipas",
 			"iso_code": "MX-TAM",
 			"postal_code_pattern": "8[7-9]"
 		},
-		"Tlax.": {
+		"TLA": {
 			"name": "Tlaxcala",
 			"iso_code": "MX-TLA",
 			"postal_code_pattern": "90"
 		},
-		"Ver.": {
+		"VER": {
 			"name": "Veracruz",
 			"iso_code": "MX-VER",
 			"postal_code_pattern": "9[1-6]"
 		},
-		"Yuc.": {
+		"YUC": {
 			"name": "Yucatán",
 			"iso_code": "MX-YUC",
 			"postal_code_pattern": "97"
 		},
-		"Zac.": {
+		"ZAC": {
 			"name": "Zacatecas",
 			"iso_code": "MX-ZAC",
 			"postal_code_pattern": "9[89]"

--- a/resources/subdivision/MY.json
+++ b/resources/subdivision/MY.json
@@ -1,67 +1,83 @@
 {
 	"country_code": "MY",
 	"subdivisions": {
-		"Johor": {
+		"01": {
+			"name": "Johor",
 			"iso_code": "MY-01",
 			"postal_code_pattern": "79|8[0-6]"
 		},
-		"Kedah": {
+		"02": {
+			"name": "Kedah",
 			"iso_code": "MY-02",
 			"postal_code_pattern": "0[5-9]|34950"
 		},
-		"Kelantan": {
+		"03": {
+			"name": "Kelantan",
 			"iso_code": "MY-03",
 			"postal_code_pattern": "1[5-9]"
 		},
-		"Kuala Lumpur": {
+		"14": {
+			"name": "Kuala Lumpur",
 			"iso_code": "MY-14",
 			"postal_code_pattern": "5|60"
 		},
-		"Labuan": {
+		"15": {
+			"name": "Labuan",
 			"iso_code": "MY-15",
 			"postal_code_pattern": "87"
 		},
-		"Melaka": {
+		"04": {
+			"name": "Melaka",
 			"iso_code": "MY-04",
 			"postal_code_pattern": "7[5-8]"
 		},
-		"Negeri Sembilan": {
+		"05": {
+			"name": "Negeri Sembilan",
 			"iso_code": "MY-05",
 			"postal_code_pattern": "7[0-4]"
 		},
-		"Pahang": {
+		"06": {
+			"name": "Pahang",
 			"iso_code": "MY-06",
 			"postal_code_pattern": "2[5-8]|[346]9"
 		},
-		"Perak": {
+		"08": {
+			"name": "Perak",
 			"iso_code": "MY-08",
 			"postal_code_pattern": "3[0-6]|39000"
 		},
-		"Perlis": {
+		"09": {
+			"name": "Perlis",
 			"iso_code": "MY-09",
 			"postal_code_pattern": "0[12]"
 		},
-		"Pulau Pinang": {
+		"07": {
+			"name": "Pulau Pinang",
 			"iso_code": "MY-07",
 			"postal_code_pattern": "1[0-4]"
 		},
-		"Putrajaya": {
+		"16": {
+			"name": "Putrajaya",
 			"iso_code": "MY-16",
 			"postal_code_pattern": "62"
 		},
-		"Sabah": {
+		"12": {
+			"name": "Sabah",
 			"iso_code": "MY-12",
 			"postal_code_pattern": "8[89]|9[01]"
 		},
-		"Sarawak": {
+		"13": {
+			"name": "Sarawak",
 			"iso_code": "MY-13",
 			"postal_code_pattern": "9[3-8]"
 		},
-		"Selangor": {
+		"10": {
+			"name": "Selangor",
 			"iso_code": "MY-10",
 			"postal_code_pattern": "4[0-8]|6[3-8]"
 		},
-		"Terengganu": {
+		"11": {
+			"name": "Terengganu",
 			"iso_code": "MY-11",
 			"postal_code_pattern": "2[0-4]"
 		}

--- a/resources/subdivision/MZ.json
+++ b/resources/subdivision/MZ.json
@@ -1,37 +1,48 @@
 {
 	"country_code": "MZ",
 	"subdivisions": {
-		"Cabo Delgado": {
+		"P": {
+			"name": "Cabo Delgado",
 			"iso_code": "MZ-P"
 		},
-		"Cidade de Maputo": {
+		"MPM": {
+			"name": "Cidade de Maputo",
 			"iso_code": "MZ-MPM"
 		},
-		"Gaza": {
+		"G": {
+			"name": "Gaza",
 			"iso_code": "MZ-G"
 		},
-		"Inhambane": {
+		"I": {
+			"name": "Inhambane",
 			"iso_code": "MZ-I"
 		},
-		"Manica": {
+		"B": {
+			"name": "Manica",
 			"iso_code": "MZ-B"
 		},
-		"Maputo": {
+		"L": {
+			"name": "Maputo",
 			"iso_code": "MZ-L"
 		},
-		"Nampula": {
+		"N": {
+			"name": "Nampula",
 			"iso_code": "MZ-N"
 		},
-		"Niassa": {
+		"A": {
+			"name": "Niassa",
 			"iso_code": "MZ-A"
 		},
-		"Sofala": {
+		"S": {
+			"name": "Sofala",
 			"iso_code": "MZ-S"
 		},
-		"Tete": {
+		"T": {
+			"name": "Tete",
 			"iso_code": "MZ-T"
 		},
-		"Zambezia": {
+		"Q": {
+			"name": "Zambezia",
 			"iso_code": "MZ-Q"
 		}
 	}

--- a/resources/subdivision/NG.json
+++ b/resources/subdivision/NG.json
@@ -1,115 +1,152 @@
 {
 	"country_code": "NG",
 	"subdivisions": {
-		"Abia": {
+		"AB": {
+			"name": "Abia",
 			"iso_code": "NG-AB"
 		},
-		"Adamawa": {
+		"AD": {
+			"name": "Adamawa",
 			"iso_code": "NG-AD"
 		},
-		"Akwa Ibom": {
+		"AK": {
+			"name": "Akwa Ibom",
 			"iso_code": "NG-AK"
 		},
-		"Anambra": {
+		"AN": {
+			"name": "Anambra",
 			"iso_code": "NG-AN"
 		},
-		"Bauchi": {
+		"BA": {
+			"name": "Bauchi",
 			"iso_code": "NG-BA"
 		},
-		"Bayelsa": {
+		"BY": {
+			"name": "Bayelsa",
 			"iso_code": "NG-BY"
 		},
-		"Benue": {
+		"BE": {
+			"name": "Benue",
 			"iso_code": "NG-BE"
 		},
-		"Borno": {
+		"BO": {
+			"name": "Borno",
 			"iso_code": "NG-BO"
 		},
-		"Cross River": {
+		"CR": {
+			"name": "Cross River",
 			"iso_code": "NG-CR"
 		},
-		"Delta": {
+		"DE": {
+			"name": "Delta",
 			"iso_code": "NG-DE"
 		},
-		"Ebonyi": {
+		"EB": {
+			"name": "Ebonyi",
 			"iso_code": "NG-EB"
 		},
-		"Edo": {
+		"ED": {
+			"name": "Edo",
 			"iso_code": "NG-ED"
 		},
-		"Ekiti": {
+		"EK": {
+			"name": "Ekiti",
 			"iso_code": "NG-EK"
 		},
-		"Enugu": {
+		"EN": {
+			"name": "Enugu",
 			"iso_code": "NG-EN"
 		},
-		"Federal Capital Territory": {
+		"FC": {
+			"name": "Federal Capital Territory",
 			"iso_code": "NG-FC"
 		},
-		"Gombe": {
+		"GO": {
+			"name": "Gombe",
 			"iso_code": "NG-GO"
 		},
-		"Imo": {
+		"IM": {
+			"name": "Imo",
 			"iso_code": "NG-IM"
 		},
-		"Jigawa": {
+		"JI": {
+			"name": "Jigawa",
 			"iso_code": "NG-JI"
 		},
-		"Kaduna": {
+		"KD": {
+			"name": "Kaduna",
 			"iso_code": "NG-KD"
 		},
-		"Kano": {
+		"KN": {
+			"name": "Kano",
 			"iso_code": "NG-KN"
 		},
-		"Katsina": {
+		"KT": {
+			"name": "Katsina",
 			"iso_code": "NG-KT"
 		},
-		"Kebbi": {
+		"KE": {
+			"name": "Kebbi",
 			"iso_code": "NG-KE"
 		},
-		"Kogi": {
+		"KO": {
+			"name": "Kogi",
 			"iso_code": "NG-KO"
 		},
-		"Kwara": {
+		"KW": {
+			"name": "Kwara",
 			"iso_code": "NG-KW"
 		},
-		"Lagos": {
+		"LA": {
+			"name": "Lagos",
 			"iso_code": "NG-LA"
 		},
-		"Nasarawa": {
+		"NA": {
+			"name": "Nasarawa",
 			"iso_code": "NG-NA"
 		},
-		"Niger": {
+		"NI": {
+			"name": "Niger",
 			"iso_code": "NG-NI"
 		},
-		"Ogun State": {
+		"OG": {
+			"name": "Ogun State",
 			"iso_code": "NG-OG"
 		},
-		"Ondo": {
+		"ON": {
+			"name": "Ondo",
 			"iso_code": "NG-ON"
 		},
-		"Osun": {
+		"OS": {
+			"name": "Osun",
 			"iso_code": "NG-OS"
 		},
-		"Oyo": {
+		"OY": {
+			"name": "Oyo",
 			"iso_code": "NG-OY"
 		},
-		"Plateau": {
+		"PL": {
+			"name": "Plateau",
 			"iso_code": "NG-PL"
 		},
-		"Rivers": {
+		"RI": {
+			"name": "Rivers",
 			"iso_code": "NG-RI"
 		},
-		"Sokoto": {
+		"SO": {
+			"name": "Sokoto",
 			"iso_code": "NG-SO"
 		},
-		"Taraba": {
+		"TA": {
+			"name": "Taraba",
 			"iso_code": "NG-TA"
 		},
-		"Yobe": {
+		"YO": {
+			"name": "Yobe",
 			"iso_code": "NG-YO"
 		},
-		"Zamfara": {
+		"ZA": {
+			"name": "Zamfara",
 			"iso_code": "NG-ZA"
 		}
 	}

--- a/resources/subdivision/NI.json
+++ b/resources/subdivision/NI.json
@@ -1,71 +1,88 @@
 {
 	"country_code": "NI",
 	"subdivisions": {
-		"Boaco": {
+		"BO": {
+			"name": "Boaco",
 			"iso_code": "NI-BO",
 			"postal_code_pattern": "5[12]"
 		},
-		"Carazo": {
+		"CA": {
+			"name": "Carazo",
 			"iso_code": "NI-CA",
 			"postal_code_pattern": "4[56]"
 		},
-		"Chinandega": {
+		"CI": {
+			"name": "Chinandega",
 			"iso_code": "NI-CI",
 			"postal_code_pattern": "2[5-7]"
 		},
-		"Chontales": {
+		"CO": {
+			"name": "Chontales",
 			"iso_code": "NI-CO",
 			"postal_code_pattern": "5[56]"
 		},
-		"Estelí": {
+		"ES": {
+			"name": "Estelí",
 			"iso_code": "NI-ES",
 			"postal_code_pattern": "3[12]"
 		},
-		"Granada": {
+		"GR": {
+			"name": "Granada",
 			"iso_code": "NI-GR",
 			"postal_code_pattern": "4[34]"
 		},
-		"Jinotega": {
+		"JI": {
+			"name": "Jinotega",
 			"iso_code": "NI-JI",
 			"postal_code_pattern": "6[56]"
 		},
-		"León": {
+		"LE": {
+			"name": "León",
 			"iso_code": "NI-LE",
 			"postal_code_pattern": "2[12]"
 		},
-		"Madriz": {
+		"MD": {
+			"name": "Madriz",
 			"iso_code": "NI-MD",
 			"postal_code_pattern": "3[45]"
 		},
-		"Managua": {
+		"MN": {
+			"name": "Managua",
 			"iso_code": "NI-MN",
 			"postal_code_pattern": "1[0-6]"
 		},
-		"Masaya": {
+		"MS": {
+			"name": "Masaya",
 			"iso_code": "NI-MS",
 			"postal_code_pattern": "4[12]"
 		},
-		"Matagalpa": {
+		"MT": {
+			"name": "Matagalpa",
 			"iso_code": "NI-MT",
 			"postal_code_pattern": "6[1-3]"
 		},
-		"Nueva Segovia": {
+		"NS": {
+			"name": "Nueva Segovia",
 			"iso_code": "NI-NS",
 			"postal_code_pattern": "3[7-9]"
 		},
-		"Región Autónoma de la Costa Caribe Norte": {
+		"AN": {
+			"name": "Región Autónoma de la Costa Caribe Norte",
 			"iso_code": "NI-AN",
 			"postal_code_pattern": "7[12]"
 		},
-		"Región Autónoma de la Costa Caribe Sur": {
+		"AS": {
+			"name": "Región Autónoma de la Costa Caribe Sur",
 			"iso_code": "NI-AS",
 			"postal_code_pattern": "8[1-3]"
 		},
-		"Río San Juan": {
+		"SJ": {
+			"name": "Río San Juan",
 			"iso_code": "NI-SJ",
 			"postal_code_pattern": "9[12]"
 		},
-		"Rivas": {
+		"RI": {
+			"name": "Rivas",
 			"iso_code": "NI-RI",
 			"postal_code_pattern": "4[78]"
 		}

--- a/resources/subdivision/NR.json
+++ b/resources/subdivision/NR.json
@@ -1,46 +1,60 @@
 {
 	"country_code": "NR",
 	"subdivisions": {
-		"Aiwo District": {
+		"01": {
+			"name": "Aiwo District",
 			"iso_code": "NR-01"
 		},
-		"Anabar District": {
+		"02": {
+			"name": "Anabar District",
 			"iso_code": "NR-02"
 		},
-		"Anetan District": {
+		"03": {
+			"name": "Anetan District",
 			"iso_code": "NR-03"
 		},
-		"Anibare District": {
+		"04": {
+			"name": "Anibare District",
 			"iso_code": "NR-04"
 		},
-		"Baiti District": {
+		"05": {
+			"name": "Baiti District",
 			"iso_code": "NR-05"
 		},
-		"Boe District": {
+		"06": {
+			"name": "Boe District",
 			"iso_code": "NR-06"
 		},
-		"Buada District": {
+		"07": {
+			"name": "Buada District",
 			"iso_code": "NR-07"
 		},
-		"Denigomodu District": {
+		"08": {
+			"name": "Denigomodu District",
 			"iso_code": "NR-08"
 		},
-		"Ewa District": {
+		"09": {
+			"name": "Ewa District",
 			"iso_code": "NR-09"
 		},
-		"Ijuw District": {
+		"10": {
+			"name": "Ijuw District",
 			"iso_code": "NR-10"
 		},
-		"Meneng District": {
+		"11": {
+			"name": "Meneng District",
 			"iso_code": "NR-11"
 		},
-		"Nibok District": {
+		"12": {
+			"name": "Nibok District",
 			"iso_code": "NR-12"
 		},
-		"Uaboe District": {
+		"13": {
+			"name": "Uaboe District",
 			"iso_code": "NR-13"
 		},
-		"Yaren District": {
+		"14": {
+			"name": "Yaren District",
 			"iso_code": "NR-14"
 		}
 	}

--- a/resources/subdivision/PE.json
+++ b/resources/subdivision/PE.json
@@ -1,82 +1,108 @@
 {
 	"country_code": "PE",
 	"subdivisions": {
-		"Amazonas": {
+		"AMA": {
+			"name": "Amazonas",
 			"iso_code": "PE-AMA"
 		},
-		"Áncash": {
+		"ANC": {
+			"name": "Áncash",
 			"iso_code": "PE-ANC"
 		},
-		"Apurímac": {
+		"APU": {
+			"name": "Apurímac",
 			"iso_code": "PE-APU"
 		},
-		"Arequipa": {
+		"ARE": {
+			"name": "Arequipa",
 			"iso_code": "PE-ARE"
 		},
-		"Ayacucho": {
+		"AYA": {
+			"name": "Ayacucho",
 			"iso_code": "PE-AYA"
 		},
-		"Cajamarca": {
+		"CAJ": {
+			"name": "Cajamarca",
 			"iso_code": "PE-CAJ"
 		},
-		"Callao": {
+		"CAL": {
+			"name": "Callao",
 			"iso_code": "PE-CAL"
 		},
-		"Cuzco": {
+		"CUS": {
+			"name": "Cuzco",
 			"iso_code": "PE-CUS"
 		},
-		"Gobierno Regional de Lima": {
+		"LIM": {
+			"name": "Gobierno Regional de Lima",
 			"iso_code": "PE-LIM"
 		},
-		"Huancavelica": {
+		"HUV": {
+			"name": "Huancavelica",
 			"iso_code": "PE-HUV"
 		},
-		"Huánuco": {
+		"HUC": {
+			"name": "Huánuco",
 			"iso_code": "PE-HUC"
 		},
-		"Ica": {
+		"ICA": {
+			"name": "Ica",
 			"iso_code": "PE-ICA"
 		},
-		"Junín": {
+		"JUN": {
+			"name": "Junín",
 			"iso_code": "PE-JUN"
 		},
-		"La Libertad": {
+		"LAL": {
+			"name": "La Libertad",
 			"iso_code": "PE-LAL"
 		},
-		"Lambayeque": {
+		"LAM": {
+			"name": "Lambayeque",
 			"iso_code": "PE-LAM"
 		},
-		"Loreto": {
+		"LOR": {
+			"name": "Loreto",
 			"iso_code": "PE-LOR"
 		},
-		"Madre de Dios": {
+		"MDD": {
+			"name": "Madre de Dios",
 			"iso_code": "PE-MDD"
 		},
-		"Moquegua": {
+		"MOQ": {
+			"name": "Moquegua",
 			"iso_code": "PE-MOQ"
 		},
-		"Municipalidad Metropolitana de Lima": {
+		"LMA": {
+			"name": "Municipalidad Metropolitana de Lima",
 			"iso_code": "PE-LMA"
 		},
-		"Pasco": {
+		"PAS": {
+			"name": "Pasco",
 			"iso_code": "PE-PAS"
 		},
-		"Piura": {
+		"PIU": {
+			"name": "Piura",
 			"iso_code": "PE-PIU"
 		},
-		"Puno": {
+		"PUN": {
+			"name": "Puno",
 			"iso_code": "PE-PUN"
 		},
-		"San Martín": {
+		"SAM": {
+			"name": "San Martín",
 			"iso_code": "PE-SAM"
 		},
-		"Tacna": {
+		"TAC": {
+			"name": "Tacna",
 			"iso_code": "PE-TAC"
 		},
-		"Tumbes": {
+		"TUM": {
+			"name": "Tumbes",
 			"iso_code": "PE-TUM"
 		},
-		"Ucayali": {
+		"UCA": {
+			"name": "Ucayali",
 			"iso_code": "PE-UCA"
 		}
 	}

--- a/resources/subdivision/PH.json
+++ b/resources/subdivision/PH.json
@@ -1,330 +1,412 @@
 {
 	"country_code": "PH",
 	"subdivisions": {
-		"Abra": {
+		"ABR": {
+			"name": "Abra",
 			"iso_code": "PH-ABR",
 			"postal_code_pattern": "28[0-2]"
 		},
-		"Agusan del Norte": {
+		"AGN": {
+			"name": "Agusan del Norte",
 			"iso_code": "PH-AGN",
 			"postal_code_pattern": "86[01]"
 		},
-		"Agusan del Sur": {
+		"AGS": {
+			"name": "Agusan del Sur",
 			"iso_code": "PH-AGS",
 			"postal_code_pattern": "85[01]"
 		},
-		"Aklan": {
+		"AKL": {
+			"name": "Aklan",
 			"iso_code": "PH-AKL",
 			"postal_code_pattern": "56[01]"
 		},
-		"Albay": {
+		"ALB": {
+			"name": "Albay",
 			"iso_code": "PH-ALB",
 			"postal_code_pattern": "45[01]"
 		},
-		"Antique": {
+		"ANT": {
+			"name": "Antique",
 			"iso_code": "PH-ANT",
 			"postal_code_pattern": "57[01]"
 		},
-		"Apayao": {
+		"APA": {
+			"name": "Apayao",
 			"iso_code": "PH-APA",
 			"postal_code_pattern": "380[0-68]"
 		},
-		"Aurora": {
+		"AUR": {
+			"name": "Aurora",
 			"iso_code": "PH-AUR",
 			"postal_code_pattern": "320"
 		},
-		"Basilan": {
+		"BAS": {
+			"name": "Basilan",
 			"iso_code": "PH-BAS",
 			"postal_code_pattern": "730"
 		},
-		"Bataan": {
+		"BAN": {
+			"name": "Bataan",
 			"iso_code": "PH-BAN",
 			"postal_code_pattern": "21[01]"
 		},
-		"Batanes": {
+		"BTN": {
+			"name": "Batanes",
 			"iso_code": "PH-BTN",
 			"postal_code_pattern": "390"
 		},
-		"Batangas": {
+		"BTG": {
+			"name": "Batangas",
 			"iso_code": "PH-BTG",
 			"postal_code_pattern": "42[0-3]"
 		},
-		"Benguet": {
+		"BEN": {
+			"name": "Benguet",
 			"iso_code": "PH-BEN",
 			"postal_code_pattern": "26(0|1[0-5])"
 		},
-		"Biliran": {
+		"BIL": {
+			"name": "Biliran",
 			"iso_code": "PH-BIL",
 			"postal_code_pattern": "65(4[3-9]|5)"
 		},
-		"Bohol": {
+		"BOH": {
+			"name": "Bohol",
 			"iso_code": "PH-BOH",
 			"postal_code_pattern": "63[0-3]"
 		},
-		"Bukidnon": {
+		"BUK": {
+			"name": "Bukidnon",
 			"iso_code": "PH-BUK",
 			"postal_code_pattern": "87[0-2]"
 		},
-		"Bulacan": {
+		"BUL": {
+			"name": "Bulacan",
 			"iso_code": "PH-BUL",
 			"postal_code_pattern": "30[0-2]"
 		},
-		"Cagayan": {
+		"CAG": {
+			"name": "Cagayan",
 			"iso_code": "PH-CAG",
 			"postal_code_pattern": "35[0-2]"
 		},
-		"Camarines Norte": {
+		"CAN": {
+			"name": "Camarines Norte",
 			"iso_code": "PH-CAN",
 			"postal_code_pattern": "46[01]"
 		},
-		"Camarines Sur": {
+		"CAS": {
+			"name": "Camarines Sur",
 			"iso_code": "PH-CAS",
 			"postal_code_pattern": "44[0-3]"
 		},
-		"Camiguin": {
+		"CAM": {
+			"name": "Camiguin",
 			"iso_code": "PH-CAM",
 			"postal_code_pattern": "910"
 		},
-		"Capiz": {
+		"CAP": {
+			"name": "Capiz",
 			"iso_code": "PH-CAP",
 			"postal_code_pattern": "58[01]"
 		},
-		"Catanduanes": {
+		"CAT": {
+			"name": "Catanduanes",
 			"iso_code": "PH-CAT",
 			"postal_code_pattern": "48[01]"
 		},
-		"Cavite": {
+		"CAV": {
+			"name": "Cavite",
 			"iso_code": "PH-CAV",
 			"postal_code_pattern": "41[0-2]"
 		},
-		"Cebu": {
+		"CEB": {
+			"name": "Cebu",
 			"iso_code": "PH-CEB",
 			"postal_code_pattern": "60[0-5]"
 		},
-		"Compostela Valley": {
+		"COM": {
+			"name": "Compostela Valley",
 			"iso_code": "PH-COM",
 			"postal_code_pattern": "88[01]"
 		},
-		"Cotabato": {
+		"NCO": {
+			"name": "Cotabato",
 			"iso_code": "PH-NCO",
 			"postal_code_pattern": "94[01]"
 		},
-		"Davao del Norte": {
+		"DAV": {
+			"name": "Davao del Norte",
 			"iso_code": "PH-DAV",
 			"postal_code_pattern": "81[0-2]"
 		},
-		"Davao del Sur": {
+		"DAS": {
+			"name": "Davao del Sur",
 			"iso_code": "PH-DAS",
 			"postal_code_pattern": "80[01]"
 		},
-		"Davao Occidental": {
+		"DVO": {
+			"name": "Davao Occidental",
 			"iso_code": "PH-DVO",
 			"postal_code_pattern": "801[1-5]"
 		},
-		"Davao Oriental": {
+		"DAO": {
+			"name": "Davao Oriental",
 			"iso_code": "PH-DAO",
 			"postal_code_pattern": "82[01]"
 		},
-		"Dinagat Islands": {
+		"DIN": {
+			"name": "Dinagat Islands",
 			"iso_code": "PH-DIN",
 			"postal_code_pattern": "84[12]"
 		},
-		"Eastern Samar": {
+		"EAS": {
+			"name": "Eastern Samar",
 			"iso_code": "PH-EAS",
 			"postal_code_pattern": "68[0-2]"
 		},
-		"Guimaras": {
+		"GUI": {
+			"name": "Guimaras",
 			"iso_code": "PH-GUI",
 			"postal_code_pattern": "504[4-6]"
 		},
-		"Ifugao": {
+		"IFU": {
+			"name": "Ifugao",
 			"iso_code": "PH-IFU",
 			"postal_code_pattern": "36[01]"
 		},
-		"Ilocos Norte": {
+		"ILN": {
+			"name": "Ilocos Norte",
 			"iso_code": "PH-ILN",
 			"postal_code_pattern": "29[0-2]"
 		},
-		"Ilocos Sur": {
+		"ILS": {
+			"name": "Ilocos Sur",
 			"iso_code": "PH-ILS",
 			"postal_code_pattern": "27[0-3]"
 		},
-		"Iloilo": {
+		"ILI": {
+			"name": "Iloilo",
 			"iso_code": "PH-ILI",
 			"postal_code_pattern": "50([0-3]|4[0-3])"
 		},
-		"Isabela": {
+		"ISA": {
+			"name": "Isabela",
 			"iso_code": "PH-ISA",
 			"postal_code_pattern": "33[0-3]"
 		},
-		"Kalinga": {
+		"KAL": {
+			"name": "Kalinga",
 			"iso_code": "PH-KAL",
 			"postal_code_pattern": "38(0[79]|1[0-4])"
 		},
-		"La Union": {
+		"LUN": {
+			"name": "La Union",
 			"iso_code": "PH-LUN",
 			"postal_code_pattern": "25[0-2]"
 		},
-		"Laguna": {
+		"LAG": {
+			"name": "Laguna",
 			"iso_code": "PH-LAG",
 			"postal_code_pattern": "40[0-3]"
 		},
-		"Lanao del Norte": {
+		"LAN": {
+			"name": "Lanao del Norte",
 			"iso_code": "PH-LAN",
 			"postal_code_pattern": "92[0-2]"
 		},
-		"Lanao del Sur": {
+		"LAS": {
+			"name": "Lanao del Sur",
 			"iso_code": "PH-LAS",
 			"postal_code_pattern": "9(3[0-2]|7[01])"
 		},
-		"Leyte": {
+		"LEY": {
+			"name": "Leyte",
 			"iso_code": "PH-LEY",
 			"postal_code_pattern": "65([0-3]|4[0-2])"
 		},
-		"Maguindanao": {
+		"MAG": {
+			"name": "Maguindanao",
 			"iso_code": "PH-MAG",
 			"postal_code_pattern": "96[01]"
 		},
-		"Marinduque": {
+		"MAD": {
+			"name": "Marinduque",
 			"iso_code": "PH-MAD",
 			"postal_code_pattern": "490"
 		},
-		"Masbate": {
+		"MAS": {
+			"name": "Masbate",
 			"iso_code": "PH-MAS",
 			"postal_code_pattern": "54[0-2]"
 		},
-		"Metro Manila": {
+		"00": {
+			"name": "Metro Manila",
 			"iso_code": "PH-00"
 		},
-		"Mindoro Occidental": {
+		"MDC": {
+			"name": "Mindoro Occidental",
 			"iso_code": "PH-MDC",
 			"postal_code_pattern": "51[01]"
 		},
-		"Mindoro Oriental": {
+		"MDR": {
+			"name": "Mindoro Oriental",
 			"iso_code": "PH-MDR",
 			"postal_code_pattern": "52[01]"
 		},
-		"Misamis Occidental": {
+		"MSC": {
+			"name": "Misamis Occidental",
 			"iso_code": "PH-MSC",
 			"postal_code_pattern": "72[01]"
 		},
-		"Misamis Oriental": {
+		"MSR": {
+			"name": "Misamis Oriental",
 			"iso_code": "PH-MSR",
 			"postal_code_pattern": "90[0-2]"
 		},
-		"Mountain Province": {
+		"MOU": {
+			"name": "Mountain Province",
 			"iso_code": "PH-MOU",
 			"postal_code_pattern": "26(1[6-9]|2[0-5])"
 		},
-		"Negros Occidental": {
+		"NEC": {
+			"name": "Negros Occidental",
 			"iso_code": "PH-NEC",
 			"postal_code_pattern": "61[0-3]"
 		},
-		"Negros Oriental": {
+		"NER": {
+			"name": "Negros Oriental",
 			"iso_code": "PH-NER",
 			"postal_code_pattern": "62[0-2]"
 		},
-		"Northern Samar": {
+		"NSA": {
+			"name": "Northern Samar",
 			"iso_code": "PH-NSA",
 			"postal_code_pattern": "64[0-2]"
 		},
-		"Nueva Ecija": {
+		"NUE": {
+			"name": "Nueva Ecija",
 			"iso_code": "PH-NUE",
 			"postal_code_pattern": "31[0-3]"
 		},
-		"Nueva Vizcaya": {
+		"NUV": {
+			"name": "Nueva Vizcaya",
 			"iso_code": "PH-NUV",
 			"postal_code_pattern": "37[01]"
 		},
-		"Palawan": {
+		"PLW": {
+			"name": "Palawan",
 			"iso_code": "PH-PLW",
 			"postal_code_pattern": "53[0-2]"
 		},
-		"Pampanga": {
+		"PAM": {
+			"name": "Pampanga",
 			"iso_code": "PH-PAM",
 			"postal_code_pattern": "20[0-2]"
 		},
-		"Pangasinan": {
+		"PAN": {
+			"name": "Pangasinan",
 			"iso_code": "PH-PAN",
 			"postal_code_pattern": "24[0-4]"
 		},
-		"Quezon Province": {
+		"QUE": {
+			"name": "Quezon Province",
 			"iso_code": "PH-QUE",
 			"postal_code_pattern": "43[0-4]"
 		},
-		"Quirino": {
+		"QUI": {
+			"name": "Quirino",
 			"iso_code": "PH-QUI",
 			"postal_code_pattern": "340"
 		},
-		"Rizal": {
+		"RIZ": {
+			"name": "Rizal",
 			"iso_code": "PH-RIZ",
 			"postal_code_pattern": "1[89]"
 		},
-		"Romblon": {
+		"ROM": {
+			"name": "Romblon",
 			"iso_code": "PH-ROM",
 			"postal_code_pattern": "55[01]"
 		},
-		"Samar": {
+		"WSA": {
+			"name": "Samar",
 			"iso_code": "PH-WSA",
 			"postal_code_pattern": "67[0-2]"
 		},
-		"Sarangani": {
+		"SAR": {
+			"name": "Sarangani",
 			"iso_code": "PH-SAR",
 			"postal_code_pattern": "8015"
 		},
-		"Siquijor": {
+		"SIG": {
+			"name": "Siquijor",
 			"iso_code": "PH-SIG",
 			"postal_code_pattern": "62(2[5-9]|30)"
 		},
-		"Sorsogon": {
+		"SOR": {
+			"name": "Sorsogon",
 			"iso_code": "PH-SOR",
 			"postal_code_pattern": "47[01]"
 		},
-		"South Cotabato": {
+		"SCO": {
+			"name": "South Cotabato",
 			"iso_code": "PH-SCO",
 			"postal_code_pattern": "95[01]"
 		},
-		"Southern Leyte": {
+		"SLE": {
+			"name": "Southern Leyte",
 			"iso_code": "PH-SLE",
 			"postal_code_pattern": "66[10]"
 		},
-		"Sultan Kudarat": {
+		"SUK": {
+			"name": "Sultan Kudarat",
 			"iso_code": "PH-SUK",
 			"postal_code_pattern": "98[01]"
 		},
-		"Sulu": {
+		"SLU": {
+			"name": "Sulu",
 			"iso_code": "PH-SLU",
 			"postal_code_pattern": "74[01]"
 		},
-		"Surigao del Norte": {
+		"SUN": {
+			"name": "Surigao del Norte",
 			"iso_code": "PH-SUN",
 			"postal_code_pattern": "84[0-2]"
 		},
-		"Surigao del Sur": {
+		"SUR": {
+			"name": "Surigao del Sur",
 			"iso_code": "PH-SUR",
 			"postal_code_pattern": "83[01]"
 		},
-		"Tarlac": {
+		"TAR": {
+			"name": "Tarlac",
 			"iso_code": "PH-TAR",
 			"postal_code_pattern": "23[01]"
 		},
-		"Tawi-Tawi": {
+		"TAW": {
+			"name": "Tawi-Tawi",
 			"iso_code": "PH-TAW",
 			"postal_code_pattern": "750"
 		},
-		"Zambales": {
+		"ZMB": {
+			"name": "Zambales",
 			"iso_code": "PH-ZMB",
 			"postal_code_pattern": "22[01]"
 		},
-		"Zamboanga del Norte": {
+		"ZAN": {
+			"name": "Zamboanga del Norte",
 			"iso_code": "PH-ZAN",
 			"postal_code_pattern": "71[0-2]"
 		},
-		"Zamboanga del Sur": {
+		"ZAS": {
+			"name": "Zamboanga del Sur",
 			"iso_code": "PH-ZAS",
 			"postal_code_pattern": "70[0-4]"
 		},
-		"Zamboanga Sibuguey": {
+		"ZSI": {
+			"name": "Zamboanga Sibuguey",
 			"iso_code": "PH-ZSI",
 			"postal_code_pattern": "70[0-4]"
 		}

--- a/resources/subdivision/SO.json
+++ b/resources/subdivision/SO.json
@@ -1,7 +1,7 @@
 {
 	"country_code": "SO",
 	"subdivisions": {
-		"AD": {
+		"AW": {
 			"name": "Awdal",
 			"iso_code": "SO-AW"
 		},
@@ -21,15 +21,15 @@
 			"name": "Bay",
 			"iso_code": "SO-BY"
 		},
-		"GG": {
+		"GA": {
 			"name": "Galguduud",
 			"iso_code": "SO-GA"
 		},
-		"GD": {
+		"GE": {
 			"name": "Gedo",
 			"iso_code": "SO-GE"
 		},
-		"HR": {
+		"HI": {
 			"name": "Hiiraan",
 			"iso_code": "SO-HI"
 		},
@@ -41,15 +41,15 @@
 			"name": "Jubbada Hoose",
 			"iso_code": "SO-JH"
 		},
-		"MD": {
+		"MU": {
 			"name": "Mudug",
 			"iso_code": "SO-MU"
 		},
-		"NG": {
+		"NU": {
 			"name": "Nugaal",
 			"iso_code": "SO-NU"
 		},
-		"SG": {
+		"SA": {
 			"name": "Sanaag",
 			"iso_code": "SO-SA"
 		},
@@ -61,15 +61,15 @@
 			"name": "Shabeellaha Hoose",
 			"iso_code": "SO-SH"
 		},
-		"SL": {
+		"SO": {
 			"name": "Sool",
 			"iso_code": "SO-SO"
 		},
-		"TG": {
+		"TO": {
 			"name": "Togdheer",
 			"iso_code": "SO-TO"
 		},
-		"WG": {
+		"WO": {
 			"name": "Woqooyi Galbeed",
 			"iso_code": "SO-WO"
 		}

--- a/resources/subdivision/SR.json
+++ b/resources/subdivision/SR.json
@@ -1,34 +1,44 @@
 {
 	"country_code": "SR",
 	"subdivisions": {
-		"Brokopondo": {
+		"BR": {
+			"name": "Brokopondo",
 			"iso_code": "SR-BR"
 		},
-		"Commewijne": {
+		"CM": {
+			"name": "Commewijne",
 			"iso_code": "SR-CM"
 		},
-		"Coronie": {
+		"CR": {
+			"name": "Coronie",
 			"iso_code": "SR-CR"
 		},
-		"Marowijne": {
+		"MA": {
+			"name": "Marowijne",
 			"iso_code": "SR-MA"
 		},
-		"Nickerie": {
+		"NI": {
+			"name": "Nickerie",
 			"iso_code": "SR-NI"
 		},
-		"Para": {
+		"PR": {
+			"name": "Para",
 			"iso_code": "SR-PR"
 		},
-		"Paramaribo": {
+		"PM": {
+			"name": "Paramaribo",
 			"iso_code": "SR-PM"
 		},
-		"Saramacca": {
+		"SA": {
+			"name": "Saramacca",
 			"iso_code": "SR-SA"
 		},
-		"Sipaliwini": {
+		"SI": {
+			"name": "Sipaliwini",
 			"iso_code": "SR-SI"
 		},
-		"Wanica": {
+		"WA": {
+			"name": "Wanica",
 			"iso_code": "SR-WA"
 		}
 	}

--- a/resources/subdivision/SV.json
+++ b/resources/subdivision/SV.json
@@ -1,65 +1,72 @@
 {
 	"country_code": "SV",
 	"subdivisions": {
-		"Ahuachapan": {
+		"AH": {
 			"name": "Ahuachapán",
 			"iso_code": "SV-AH",
 			"postal_code_pattern": "CP 21"
 		},
-		"Cabanas": {
+		"CA": {
 			"name": "Cabañas",
 			"iso_code": "SV-CA",
 			"postal_code_pattern": "CP 12"
 		},
-		"Calatenango": {
+		"CH": {
 			"name": "Chalatenango",
 			"iso_code": "SV-CH",
 			"postal_code_pattern": "CP 13"
 		},
-		"Cuscatlan": {
+		"CU": {
 			"name": "Cuscatlán",
 			"iso_code": "SV-CU",
 			"postal_code_pattern": "CP 14"
 		},
-		"La Libertad": {
+		"LI": {
+			"name": "La Libertad",
 			"iso_code": "SV-LI",
 			"postal_code_pattern": "CP 15"
 		},
-		"La Paz": {
+		"PA": {
+			"name": "La Paz",
 			"iso_code": "SV-PA",
 			"postal_code_pattern": "CP 16"
 		},
-		"La Union": {
+		"UN": {
 			"name": "La Unión",
 			"iso_code": "SV-UN",
 			"postal_code_pattern": "CP 31"
 		},
-		"Morazan": {
+		"MO": {
 			"name": "Morazán",
 			"iso_code": "SV-MO",
 			"postal_code_pattern": "CP 32"
 		},
-		"San Miguel": {
+		"SM": {
+			"name": "San Miguel",
 			"iso_code": "SV-SM",
 			"postal_code_pattern": "CP 33"
 		},
-		"San Salvador": {
+		"SS": {
+			"name": "San Salvador",
 			"iso_code": "SV-SS",
 			"postal_code_pattern": "CP 11"
 		},
-		"San Vicente": {
+		"SV": {
+			"name": "San Vicente",
 			"iso_code": "SV-SV",
 			"postal_code_pattern": "CP 17"
 		},
-		"Santa Ana": {
+		"SA": {
+			"name": "Santa Ana",
 			"iso_code": "SV-SA",
 			"postal_code_pattern": "CP 22"
 		},
-		"Sonsonate": {
+		"SO": {
+			"name": "Sonsonate",
 			"iso_code": "SV-SO",
 			"postal_code_pattern": "CP 23"
 		},
-		"Usulutan": {
+		"US": {
 			"name": "Usulután",
 			"iso_code": "SV-US",
 			"postal_code_pattern": "CP 34"

--- a/resources/subdivision/TR.json
+++ b/resources/subdivision/TR.json
@@ -1,327 +1,408 @@
 {
 	"country_code": "TR",
 	"subdivisions": {
-		"Adana": {
+		"01": {
+			"name": "Adana",
 			"iso_code": "TR-01",
 			"postal_code_pattern": "01"
 		},
-		"Adıyaman": {
+		"02": {
+			"name": "Adıyaman",
 			"iso_code": "TR-02",
 			"postal_code_pattern": "02"
 		},
-		"Afyon": {
+		"03": {
+			"name": "Afyon",
 			"iso_code": "TR-03",
 			"postal_code_pattern": "03"
 		},
-		"Ağrı": {
+		"04": {
+			"name": "Ağrı",
 			"iso_code": "TR-04",
 			"postal_code_pattern": "04"
 		},
-		"Aksaray": {
+		"68": {
+			"name": "Aksaray",
 			"iso_code": "TR-68",
 			"postal_code_pattern": "68"
 		},
-		"Amasya": {
+		"05": {
+			"name": "Amasya",
 			"iso_code": "TR-05",
 			"postal_code_pattern": "05"
 		},
-		"Ankara": {
+		"06": {
+			"name": "Ankara",
 			"iso_code": "TR-06",
 			"postal_code_pattern": "06"
 		},
-		"Antalya": {
+		"07": {
+			"name": "Antalya",
 			"iso_code": "TR-07",
 			"postal_code_pattern": "07"
 		},
-		"Ardahan": {
+		"75": {
+			"name": "Ardahan",
 			"iso_code": "TR-75",
 			"postal_code_pattern": "75"
 		},
-		"Artvin": {
+		"08": {
+			"name": "Artvin",
 			"iso_code": "TR-08",
 			"postal_code_pattern": "08"
 		},
-		"Aydın": {
+		"09": {
+			"name": "Aydın",
 			"iso_code": "TR-09",
 			"postal_code_pattern": "09"
 		},
-		"Balıkesir": {
+		"10": {
+			"name": "Balıkesir",
 			"iso_code": "TR-10",
 			"postal_code_pattern": "10"
 		},
-		"Bartın": {
+		"74": {
+			"name": "Bartın",
 			"iso_code": "TR-74",
 			"postal_code_pattern": "74"
 		},
-		"Batman": {
+		"72": {
+			"name": "Batman",
 			"iso_code": "TR-72",
 			"postal_code_pattern": "72"
 		},
-		"Bayburt": {
+		"69": {
+			"name": "Bayburt",
 			"iso_code": "TR-69",
 			"postal_code_pattern": "69"
 		},
-		"Bilecik": {
+		"11": {
+			"name": "Bilecik",
 			"iso_code": "TR-11",
 			"postal_code_pattern": "11"
 		},
-		"Bingöl": {
+		"12": {
+			"name": "Bingöl",
 			"iso_code": "TR-12",
 			"postal_code_pattern": "12"
 		},
-		"Bitlis": {
+		"13": {
+			"name": "Bitlis",
 			"iso_code": "TR-13",
 			"postal_code_pattern": "13"
 		},
-		"Bolu": {
+		"14": {
+			"name": "Bolu",
 			"iso_code": "TR-14",
 			"postal_code_pattern": "14"
 		},
-		"Burdur": {
+		"15": {
+			"name": "Burdur",
 			"iso_code": "TR-15",
 			"postal_code_pattern": "15"
 		},
-		"Bursa": {
+		"16": {
+			"name": "Bursa",
 			"iso_code": "TR-16",
 			"postal_code_pattern": "16"
 		},
-		"Çanakkale": {
+		"17": {
+			"name": "Çanakkale",
 			"iso_code": "TR-17",
 			"postal_code_pattern": "17"
 		},
-		"Çankırı": {
+		"18": {
+			"name": "Çankırı",
 			"iso_code": "TR-18",
 			"postal_code_pattern": "18"
 		},
-		"Çorum": {
+		"19": {
+			"name": "Çorum",
 			"iso_code": "TR-19",
 			"postal_code_pattern": "19"
 		},
-		"Denizli": {
+		"20": {
+			"name": "Denizli",
 			"iso_code": "TR-20",
 			"postal_code_pattern": "20"
 		},
-		"Diyarbakır": {
+		"21": {
+			"name": "Diyarbakır",
 			"iso_code": "TR-21",
 			"postal_code_pattern": "21"
 		},
-		"Düzce": {
+		"81": {
+			"name": "Düzce",
 			"iso_code": "TR-81",
 			"postal_code_pattern": "81"
 		},
-		"Edirne": {
+		"22": {
+			"name": "Edirne",
 			"iso_code": "TR-22",
 			"postal_code_pattern": "22"
 		},
-		"Elazığ": {
+		"23": {
+			"name": "Elazığ",
 			"iso_code": "TR-23",
 			"postal_code_pattern": "23"
 		},
-		"Erzincan": {
+		"24": {
+			"name": "Erzincan",
 			"iso_code": "TR-24",
 			"postal_code_pattern": "24"
 		},
-		"Erzurum": {
+		"25": {
+			"name": "Erzurum",
 			"iso_code": "TR-25",
 			"postal_code_pattern": "25"
 		},
-		"Eskişehir": {
+		"26": {
+			"name": "Eskişehir",
 			"iso_code": "TR-26",
 			"postal_code_pattern": "26"
 		},
-		"Gaziantep": {
+		"27": {
+			"name": "Gaziantep",
 			"iso_code": "TR-27",
 			"postal_code_pattern": "27"
 		},
-		"Giresun": {
+		"28": {
+			"name": "Giresun",
 			"iso_code": "TR-28",
 			"postal_code_pattern": "28"
 		},
-		"Gümüşhane": {
+		"29": {
+			"name": "Gümüşhane",
 			"iso_code": "TR-29",
 			"postal_code_pattern": "29"
 		},
-		"Hakkari": {
+		"30": {
+			"name": "Hakkari",
 			"iso_code": "TR-30",
 			"postal_code_pattern": "30"
 		},
-		"Hatay": {
+		"31": {
+			"name": "Hatay",
 			"iso_code": "TR-31",
 			"postal_code_pattern": "31"
 		},
-		"Iğdır": {
+		"76": {
+			"name": "Iğdır",
 			"iso_code": "TR-76",
 			"postal_code_pattern": "76"
 		},
-		"Isparta": {
+		"32": {
+			"name": "Isparta",
 			"iso_code": "TR-32",
 			"postal_code_pattern": "32"
 		},
-		"İstanbul": {
+		"34": {
+			"name": "İstanbul",
 			"iso_code": "TR-34",
 			"postal_code_pattern": "34"
 		},
-		"İzmir": {
+		"35": {
+			"name": "İzmir",
 			"iso_code": "TR-35",
 			"postal_code_pattern": "35"
 		},
-		"Kahramanmaraş": {
+		"46": {
+			"name": "Kahramanmaraş",
 			"iso_code": "TR-46",
 			"postal_code_pattern": "46"
 		},
-		"Karabük": {
+		"78": {
+			"name": "Karabük",
 			"iso_code": "TR-78",
 			"postal_code_pattern": "78"
 		},
-		"Karaman": {
+		"70": {
+			"name": "Karaman",
 			"iso_code": "TR-70",
 			"postal_code_pattern": "70"
 		},
-		"Kars": {
+		"36": {
+			"name": "Kars",
 			"iso_code": "TR-36",
 			"postal_code_pattern": "36"
 		},
-		"Kastamonu": {
+		"37": {
+			"name": "Kastamonu",
 			"iso_code": "TR-37",
 			"postal_code_pattern": "37"
 		},
-		"Kayseri": {
+		"38": {
+			"name": "Kayseri",
 			"iso_code": "TR-38",
 			"postal_code_pattern": "38"
 		},
-		"Kırıkkale": {
+		"71": {
+			"name": "Kırıkkale",
 			"iso_code": "TR-71",
 			"postal_code_pattern": "71"
 		},
-		"Kırklareli": {
+		"39": {
+			"name": "Kırklareli",
 			"iso_code": "TR-39",
 			"postal_code_pattern": "39"
 		},
-		"Kırşehir": {
+		"40": {
+			"name": "Kırşehir",
 			"iso_code": "TR-40",
 			"postal_code_pattern": "40"
 		},
-		"Kilis": {
+		"79": {
+			"name": "Kilis",
 			"iso_code": "TR-79",
 			"postal_code_pattern": "79"
 		},
-		"Kocaeli": {
+		"41": {
+			"name": "Kocaeli",
 			"iso_code": "TR-41",
 			"postal_code_pattern": "41"
 		},
-		"Konya": {
+		"42": {
+			"name": "Konya",
 			"iso_code": "TR-42",
 			"postal_code_pattern": "42"
 		},
-		"Kütahya": {
+		"43": {
+			"name": "Kütahya",
 			"iso_code": "TR-43",
 			"postal_code_pattern": "43"
 		},
-		"Malatya": {
+		"44": {
+			"name": "Malatya",
 			"iso_code": "TR-44",
 			"postal_code_pattern": "44"
 		},
-		"Manisa": {
+		"45": {
+			"name": "Manisa",
 			"iso_code": "TR-45",
 			"postal_code_pattern": "45"
 		},
-		"Mardin": {
+		"47": {
+			"name": "Mardin",
 			"iso_code": "TR-47",
 			"postal_code_pattern": "47"
 		},
-		"Mersin": {
+		"33": {
+			"name": "Mersin",
 			"iso_code": "TR-33",
 			"postal_code_pattern": "33"
 		},
-		"Muğla": {
+		"48": {
+			"name": "Muğla",
 			"iso_code": "TR-48",
 			"postal_code_pattern": "48"
 		},
-		"Muş": {
+		"49": {
+			"name": "Muş",
 			"iso_code": "TR-49",
 			"postal_code_pattern": "49"
 		},
-		"Nevşehir": {
+		"50": {
+			"name": "Nevşehir",
 			"iso_code": "TR-50",
 			"postal_code_pattern": "50"
 		},
-		"Niğde": {
+		"51": {
+			"name": "Niğde",
 			"iso_code": "TR-51",
 			"postal_code_pattern": "51"
 		},
-		"Ordu": {
+		"52": {
+			"name": "Ordu",
 			"iso_code": "TR-52",
 			"postal_code_pattern": "52"
 		},
-		"Osmaniye": {
+		"80": {
+			"name": "Osmaniye",
 			"iso_code": "TR-80",
 			"postal_code_pattern": "80"
 		},
-		"Rize": {
+		"53": {
+			"name": "Rize",
 			"iso_code": "TR-53",
 			"postal_code_pattern": "53"
 		},
-		"Sakarya": {
+		"54": {
+			"name": "Sakarya",
 			"iso_code": "TR-54",
 			"postal_code_pattern": "54"
 		},
-		"Samsun": {
+		"55": {
+			"name": "Samsun",
 			"iso_code": "TR-55",
 			"postal_code_pattern": "55"
 		},
-		"Siirt": {
+		"56": {
+			"name": "Siirt",
 			"iso_code": "TR-56",
 			"postal_code_pattern": "56"
 		},
-		"Sinop": {
+		"57": {
+			"name": "Sinop",
 			"iso_code": "TR-57",
 			"postal_code_pattern": "57"
 		},
-		"Sivas": {
+		"58": {
+			"name": "Sivas",
 			"iso_code": "TR-58",
 			"postal_code_pattern": "58"
 		},
-		"Şanlıurfa": {
+		"63": {
+			"name": "Şanlıurfa",
 			"iso_code": "TR-63",
 			"postal_code_pattern": "63"
 		},
-		"Şırnak": {
+		"73": {
+			"name": "Şırnak",
 			"iso_code": "TR-73",
 			"postal_code_pattern": "73"
 		},
-		"Tekirdağ": {
+		"59": {
+			"name": "Tekirdağ",
 			"iso_code": "TR-59",
 			"postal_code_pattern": "59"
 		},
-		"Tokat": {
+		"60": {
+			"name": "Tokat",
 			"iso_code": "TR-60",
 			"postal_code_pattern": "60"
 		},
-		"Trabzon": {
+		"61": {
+			"name": "Trabzon",
 			"iso_code": "TR-61",
 			"postal_code_pattern": "61"
 		},
-		"Tunceli": {
+		"62": {
+			"name": "Tunceli",
 			"iso_code": "TR-62",
 			"postal_code_pattern": "62"
 		},
-		"Uşak": {
+		"64": {
+			"name": "Uşak",
 			"iso_code": "TR-64",
 			"postal_code_pattern": "64"
 		},
-		"Van": {
+		"65": {
+			"name": "Van",
 			"iso_code": "TR-65",
 			"postal_code_pattern": "65"
 		},
-		"Yalova": {
+		"77": {
+			"name": "Yalova",
 			"iso_code": "TR-77",
 			"postal_code_pattern": "77"
 		},
-		"Yozgat": {
+		"66": {
+			"name": "Yozgat",
 			"iso_code": "TR-66",
 			"postal_code_pattern": "66"
 		},
-		"Zonguldak": {
+		"67": {
+			"name": "Zonguldak",
 			"iso_code": "TR-67",
 			"postal_code_pattern": "67"
 		}

--- a/resources/subdivision/TV.json
+++ b/resources/subdivision/TV.json
@@ -1,29 +1,37 @@
 {
 	"country_code": "TV",
 	"subdivisions": {
-		"Funafuti": {
+		"FUN": {
+			"name": "Funafuti",
 			"iso_code": "TV-FUN"
 		},
-		"Nanumanga": {
+		"NMG": {
+			"name": "Nanumanga",
 			"iso_code": "TV-NMG"
 		},
-		"Nanumea": {
+		"NMA": {
+			"name": "Nanumea",
 			"iso_code": "TV-NMA"
 		},
 		"Niulakita": [],
-		"Niutao": {
+		"NIT": {
+			"name": "Niutao",
 			"iso_code": "TV-NIT"
 		},
-		"Nui": {
+		"NUI": {
+			"name": "Nui",
 			"iso_code": "TV-NUI"
 		},
-		"Nukufetau": {
+		"NKF": {
+			"name": "Nukufetau",
 			"iso_code": "TV-NKF"
 		},
-		"Nukulaelae": {
+		"NKL": {
+			"name": "Nukulaelae",
 			"iso_code": "TV-NKL"
 		},
-		"Vaitupu": {
+		"VAI": {
+			"name": "Vaitupu",
 			"iso_code": "TV-VAI"
 		}
 	}

--- a/resources/subdivision/UY.json
+++ b/resources/subdivision/UY.json
@@ -1,79 +1,98 @@
 {
 	"country_code": "UY",
 	"subdivisions": {
-		"Artigas": {
+		"AR": {
+			"name": "Artigas",
 			"iso_code": "UY-AR",
 			"postal_code_pattern": "55"
 		},
-		"Canelones": {
+		"CA": {
+			"name": "Canelones",
 			"iso_code": "UY-CA",
 			"postal_code_pattern": "9[01]|1[456]"
 		},
-		"Cerro Largo": {
+		"CL": {
+			"name": "Cerro Largo",
 			"iso_code": "UY-CL",
 			"postal_code_pattern": "37"
 		},
-		"Colonia": {
+		"CO": {
+			"name": "Colonia",
 			"iso_code": "UY-CO",
 			"postal_code_pattern": "70|75204"
 		},
-		"Durazno": {
+		"DU": {
+			"name": "Durazno",
 			"iso_code": "UY-DU",
 			"postal_code_pattern": "97"
 		},
-		"Flores": {
+		"FS": {
+			"name": "Flores",
 			"iso_code": "UY-FS",
 			"postal_code_pattern": "85"
 		},
-		"Florida": {
+		"FD": {
+			"name": "Florida",
 			"iso_code": "UY-FD",
 			"postal_code_pattern": "94|9060|97005"
 		},
-		"Lavalleja": {
+		"LA": {
+			"name": "Lavalleja",
 			"iso_code": "UY-LA",
 			"postal_code_pattern": "30"
 		},
-		"Maldonado": {
+		"MA": {
+			"name": "Maldonado",
 			"iso_code": "UY-MA",
 			"postal_code_pattern": "20"
 		},
-		"Montevideo": {
+		"MO": {
+			"name": "Montevideo",
 			"iso_code": "UY-MO",
 			"postal_code_pattern": "1|91600"
 		},
-		"Paysandú": {
+		"PA": {
+			"name": "Paysandú",
 			"iso_code": "UY-PA",
 			"postal_code_pattern": "60"
 		},
-		"Río Negro": {
+		"RN": {
+			"name": "Río Negro",
 			"iso_code": "UY-RN",
 			"postal_code_pattern": "65|60002"
 		},
-		"Rivera": {
+		"RV": {
+			"name": "Rivera",
 			"iso_code": "UY-RV",
 			"postal_code_pattern": "40"
 		},
-		"Rocha": {
+		"RO": {
+			"name": "Rocha",
 			"iso_code": "UY-RO",
 			"postal_code_pattern": "27"
 		},
-		"Salto": {
+		"SA": {
+			"name": "Salto",
 			"iso_code": "UY-SA",
 			"postal_code_pattern": "50"
 		},
-		"San José": {
+		"SJ": {
+			"name": "San José",
 			"iso_code": "UY-SJ",
 			"postal_code_pattern": "80"
 		},
-		"Soriano": {
+		"SO": {
+			"name": "Soriano",
 			"iso_code": "UY-SO",
 			"postal_code_pattern": "75|70003"
 		},
-		"Tacuarembó": {
+		"TA": {
+			"name": "Tacuarembó",
 			"iso_code": "UY-TA",
 			"postal_code_pattern": "45"
 		},
-		"Treinta y Tres": {
+		"TT": {
+			"name": "Treinta y Tres",
 			"iso_code": "UY-TT",
 			"postal_code_pattern": "33|30203|30204|30302|37007"
 		}

--- a/resources/subdivision/VE.json
+++ b/resources/subdivision/VE.json
@@ -1,79 +1,104 @@
 {
 	"country_code": "VE",
 	"subdivisions": {
-		"Amazonas": {
+		"Z": {
+			"name": "Amazonas",
 			"iso_code": "VE-Z"
 		},
-		"Anzoátegui": {
+		"B": {
+			"name": "Anzoátegui",
 			"iso_code": "VE-B"
 		},
-		"Apure": {
+		"C": {
+			"name": "Apure",
 			"iso_code": "VE-C"
 		},
-		"Aragua": {
+		"D": {
+			"name": "Aragua",
 			"iso_code": "VE-D"
 		},
-		"Barinas": {
+		"E": {
+			"name": "Barinas",
 			"iso_code": "VE-E"
 		},
-		"Bolívar": {
+		"F": {
+			"name": "Bolívar",
 			"iso_code": "VE-F"
 		},
-		"Carabobo": {
+		"G": {
+			"name": "Carabobo",
 			"iso_code": "VE-G"
 		},
-		"Cojedes": {
+		"H": {
+			"name": "Cojedes",
 			"iso_code": "VE-H"
 		},
-		"Delta Amacuro": {
+		"Y": {
+			"name": "Delta Amacuro",
 			"iso_code": "VE-Y"
 		},
-		"Dependencias Federales": {
+		"W": {
+			"name": "Dependencias Federales",
 			"iso_code": "VE-W"
 		},
-		"Distrito Federal": {
+		"A": {
+			"name": "Distrito Federal",
 			"iso_code": "VE-A"
 		},
-		"Falcón": {
+		"I": {
+			"name": "Falcón",
 			"iso_code": "VE-I"
 		},
-		"Guárico": {
+		"J": {
+			"name": "Guárico",
 			"iso_code": "VE-J"
 		},
-		"Lara": {
+		"K": {
+			"name": "Lara",
 			"iso_code": "VE-K"
 		},
-		"Mérida": {
+		"L": {
+			"name": "Mérida",
 			"iso_code": "VE-L"
 		},
-		"Miranda": {
+		"M": {
+			"name": "Miranda",
 			"iso_code": "VE-M"
 		},
-		"Monagas": {
+		"N": {
+			"name": "Monagas",
 			"iso_code": "VE-N"
 		},
-		"Nueva Esparta": {
+		"O": {
+			"name": "Nueva Esparta",
 			"iso_code": "VE-O"
 		},
-		"Portuguesa": {
+		"P": {
+			"name": "Portuguesa",
 			"iso_code": "VE-P"
 		},
-		"Sucre": {
+		"R": {
+			"name": "Sucre",
 			"iso_code": "VE-R"
 		},
-		"Táchira": {
+		"S": {
+			"name": "Táchira",
 			"iso_code": "VE-S"
 		},
-		"Trujillo": {
+		"T": {
+			"name": "Trujillo",
 			"iso_code": "VE-T"
 		},
-		"Vargas": {
+		"X": {
+			"name": "Vargas",
 			"iso_code": "VE-X"
 		},
-		"Yaracuy": {
+		"U": {
+			"name": "Yaracuy",
 			"iso_code": "VE-U"
 		},
-		"Zulia": {
+		"V": {
+			"name": "Zulia",
 			"iso_code": "VE-V"
 		}
 	}


### PR DESCRIPTION
This includes the logic change to recompile the resource data using the ISO code as the subdivision key.

This PR replaces #188.