### PR TITLE
PHP 8.4 support: switch implicit nullable types to explicit

### DIFF
--- a/src/AddressFormat/AddressFormatHelper.php
+++ b/src/AddressFormat/AddressFormatHelper.php
@@ -26,7 +26,7 @@ final class AddressFormatHelper
      *               ]
      * @throws \ReflectionException
      */
-    public static function getGroupedFields(string $formatString, FieldOverrides $fieldOverrides = null): array
+    public static function getGroupedFields(string $formatString, ?FieldOverrides $fieldOverrides = null): array
     {
         $groupedFields = [];
         $hiddenFields = $fieldOverrides ? $fieldOverrides->getHiddenFields() : [];

--- a/src/Country/CountryRepository.php
+++ b/src/Country/CountryRepository.php
@@ -79,7 +79,7 @@ class CountryRepository implements CountryRepositoryInterface
      * @param string|null $definitionPath The path to the country definitions.
      *                               Defaults to 'resources/country'.
      */
-    public function __construct(string $defaultLocale = 'en', string $fallbackLocale = 'en', string $definitionPath = null)
+    public function __construct(string $defaultLocale = 'en', string $fallbackLocale = 'en', ?string $definitionPath = null)
     {
         $this->defaultLocale = $defaultLocale;
         $this->fallbackLocale = $fallbackLocale;
@@ -89,7 +89,7 @@ class CountryRepository implements CountryRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function get(string $countryCode, string $locale = null): Country
+    public function get(string $countryCode, ?string $locale = null): Country
     {
         $countryCode = strtoupper($countryCode);
         $baseDefinitions = $this->getBaseDefinitions();
@@ -112,7 +112,7 @@ class CountryRepository implements CountryRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function getAll(string $locale = null): array
+    public function getAll(?string $locale = null): array
     {
         $locale = $locale ?: $this->defaultLocale;
         $locale = Locale::resolve($this->availableLocales, $locale, $this->fallbackLocale);
@@ -136,7 +136,7 @@ class CountryRepository implements CountryRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function getList(string $locale = null): array
+    public function getList(?string $locale = null): array
     {
         $locale = $locale ?: $this->defaultLocale;
         $locale = Locale::resolve($this->availableLocales, $locale, $this->fallbackLocale);

--- a/src/Country/CountryRepositoryInterface.php
+++ b/src/Country/CountryRepositoryInterface.php
@@ -15,7 +15,7 @@ interface CountryRepositoryInterface
      *
      * @return Country
      */
-    public function get(string $countryCode, string $locale = null): Country;
+    public function get(string $countryCode, ?string $locale = null): Country;
 
     /**
      * Gets all countries.
@@ -24,7 +24,7 @@ interface CountryRepositoryInterface
      *
      * @return Country[] An array of countries, keyed by country code.
      */
-    public function getAll(string $locale = null): array;
+    public function getAll(?string $locale = null): array;
 
     /**
      * Gets a list of countries.
@@ -33,5 +33,5 @@ interface CountryRepositoryInterface
      *
      * @return string[] An array of country names, keyed by country code.
      */
-    public function getList(string $locale = null): array;
+    public function getList(?string $locale = null): array;
 }

--- a/src/Locale.php
+++ b/src/Locale.php
@@ -281,7 +281,7 @@ final class Locale
      * @throws UnknownLocaleException
      * @see self::getCandidates
      */
-    public static function resolve(array $availableLocales, string $locale, string $fallbackLocale = null): string
+    public static function resolve(array $availableLocales, string $locale, ?string $fallbackLocale = null): string
     {
         $locale = self::canonicalize($locale);
         $resolvedLocale = null;

--- a/src/Subdivision/SubdivisionRepository.php
+++ b/src/Subdivision/SubdivisionRepository.php
@@ -36,7 +36,7 @@ class SubdivisionRepository implements SubdivisionRepositoryInterface
      * @param AddressFormatRepositoryInterface|null $addressFormatRepository The address format repository.
      * @param null $definitionPath Path to the subdivision definitions.
      */
-    public function __construct(AddressFormatRepositoryInterface $addressFormatRepository = null, $definitionPath = null)
+    public function __construct(?AddressFormatRepositoryInterface $addressFormatRepository = null, $definitionPath = null)
     {
         $this->addressFormatRepository = $addressFormatRepository ?: new AddressFormatRepository();
         $this->definitionPath = $definitionPath ?: __DIR__ . '/../../resources/subdivision/';
@@ -72,7 +72,7 @@ class SubdivisionRepository implements SubdivisionRepositoryInterface
     /**
      * {@inheritdoc}
      */
-    public function getList(array $parents, string $locale = null): array
+    public function getList(array $parents, ?string $locale = null): array
     {
         $definitions = $this->loadDefinitions($parents);
         if (empty($definitions)) {

--- a/src/Subdivision/SubdivisionRepositoryInterface.php
+++ b/src/Subdivision/SubdivisionRepositoryInterface.php
@@ -34,5 +34,5 @@ interface SubdivisionRepositoryInterface
      *
      * @return array An array of subdivision names, keyed by code.
      */
-    public function getList(array $parents, string $locale = null): array;
+    public function getList(array $parents, ?string $locale = null): array;
 }

--- a/src/Validator/Constraints/AddressFormatConstraintValidator.php
+++ b/src/Validator/Constraints/AddressFormatConstraintValidator.php
@@ -24,7 +24,7 @@ class AddressFormatConstraintValidator extends ConstraintValidator
     /**
      * Creates an AddressFormatValidator instance.
      */
-    public function __construct(AddressFormatRepositoryInterface $addressFormatRepository = null, SubdivisionRepositoryInterface $subdivisionRepository = null)
+    public function __construct(?AddressFormatRepositoryInterface $addressFormatRepository = null, ?SubdivisionRepositoryInterface $subdivisionRepository = null)
     {
         $this->addressFormatRepository = $addressFormatRepository ?: new AddressFormatRepository();
         $this->subdivisionRepository = $subdivisionRepository ?: new SubdivisionRepository();

--- a/src/Validator/Constraints/CountryConstraintValidator.php
+++ b/src/Validator/Constraints/CountryConstraintValidator.php
@@ -12,7 +12,7 @@ class CountryConstraintValidator extends ConstraintValidator
 {
     protected CountryRepositoryInterface $countryRepository;
 
-    public function __construct(CountryRepositoryInterface $countryRepository = null)
+    public function __construct(?CountryRepositoryInterface $countryRepository = null)
     {
         $this->countryRepository = $countryRepository ?: new CountryRepository();
     }


### PR DESCRIPTION
[PHP 8.4 has deprecated implicit nullable types.](https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated). This will work as low as PHP 7.1 so no compatibility issues, but due to changed function signatures may necessitate a new major.