### PR TITLE
Warning: foreach() argument must be of type array|object null check for subdivisions

### DIFF
--- a/src/Subdivision/SubdivisionRepository.php
+++ b/src/Subdivision/SubdivisionRepository.php
@@ -75,7 +75,7 @@ class SubdivisionRepository implements SubdivisionRepositoryInterface
     public function getList(array $parents, string $locale = null): array
     {
         $definitions = $this->loadDefinitions($parents);
-        if (empty($definitions)) {
+        if (empty($definitions) || empty($definitions['subdivisions'])) {
             return [];
         }
 


### PR DESCRIPTION
If the user selects a subdivision that is not in the list, this error is thrown.

```
Warning: foreach() argument must be of type array|object, null given in CommerceGuys\Addressing\Subdivision\SubdivisionRepository->getList() (line 85 of /vendor/commerceguys/addressing/src/Subdivision/SubdivisionRepository.php).
```

![image](https://github.com/user-attachments/assets/889e308d-582c-4a2f-a4a6-f360e2bf1914)

Step to reproduce;
- alter subdivision select list (administrative-area) and select different subdivision
- or make administrative-area field input instead select list and allow user to enter freely.