### PR TITLE
ci: add tests for PHP 8.5

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,5 @@ jobs:
           bootstrap: vendor/autoload.php
           configuration: phpunit.xml
           args: --coverage-text
-          php_extensions: xdebug
           php_version: ${{ matrix.php-versions }}
           version: 9
-        env:
-          XDEBUG_MODE: coverage


### PR DESCRIPTION
xdebug, bcmath is not yet available stable for PHP 8.5
https://xdebug.org/docs/compat

i guess this is the reason or the ci fail