### PR TITLE
feat: allow doctrine/collections 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "license": "MIT",
     "require": {
         "php": ">=8.0",
-        "doctrine/collections": "^1.6 || ^2.0"
+        "doctrine/collections": "^1.6 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "symfony/validator": "^5.4 || ^6.3 || ^7.0 || ^8.0",


### PR DESCRIPTION
There are BC Breaks in version 3.
https://github.com/doctrine/collections/releases/tag/3.0.0

Accord to local test runs, it looks like this repo it not directly effected